### PR TITLE
feat(orders): grouped orders workflow — schema + status enum (#16, sprint 1)

### DIFF
--- a/prisma/migrations/20260515150000_add_batch_id_and_grouped_order_statuses/migration.sql
+++ b/prisma/migrations/20260515150000_add_batch_id_and_grouped_order_statuses/migration.sql
@@ -1,0 +1,23 @@
+-- Add batchId column to Order and replace OrderStatus enum values.
+-- New workflow: PENDING -> BATCHED -> ORDERED -> RECEIVED -> DELIVERED (with CANCELLED).
+-- Mapping for any existing rows: CONFIRMED -> BATCHED, SHIPPED -> ORDERED.
+
+ALTER TABLE "Order" ADD COLUMN "batchId" TEXT;
+CREATE INDEX "Order_batchId_idx" ON "Order"("batchId");
+
+ALTER TABLE "Order" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TYPE "OrderStatus" RENAME TO "OrderStatus_old";
+CREATE TYPE "OrderStatus" AS ENUM ('PENDING', 'BATCHED', 'ORDERED', 'RECEIVED', 'DELIVERED', 'CANCELLED');
+
+ALTER TABLE "Order"
+  ALTER COLUMN "status" TYPE "OrderStatus"
+  USING (
+    CASE "status"::text
+      WHEN 'CONFIRMED' THEN 'BATCHED'
+      WHEN 'SHIPPED' THEN 'ORDERED'
+      ELSE "status"::text
+    END
+  )::"OrderStatus";
+
+ALTER TABLE "Order" ALTER COLUMN "status" SET DEFAULT 'PENDING';
+DROP TYPE "OrderStatus_old";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,8 +120,9 @@ model Verification {
 
 enum OrderStatus {
   PENDING
-  CONFIRMED
-  SHIPPED
+  BATCHED
+  ORDERED
+  RECEIVED
   DELIVERED
   CANCELLED
 }
@@ -166,6 +167,8 @@ model Order {
   status          OrderStatus @default(PENDING)
   notes           String?
 
+  batchId         String?
+
   stripeSessionId       String?   @unique
   stripePaymentIntentId String?
   paidAt                DateTime?
@@ -178,6 +181,7 @@ model Order {
   updatedAt       DateTime    @updatedAt
 
   @@index([userId])
+  @@index([batchId])
   @@index([status])
   @@index([createdAt])
 }

--- a/src/__tests__/cart.test.ts
+++ b/src/__tests__/cart.test.ts
@@ -321,8 +321,9 @@ describe("checkoutSchema", () => {
 describe("order status transitions", () => {
   const VALID_STATUSES = [
     "PENDING",
-    "CONFIRMED",
-    "SHIPPED",
+    "BATCHED",
+    "ORDERED",
+    "RECEIVED",
     "DELIVERED",
     "CANCELLED",
   ] as const;
@@ -340,15 +341,29 @@ describe("order status transitions", () => {
     ).toBe(false);
   });
 
-  it("allows PENDING -> CONFIRMED transition", () => {
+  it("rejects the old CONFIRMED status (replaced by BATCHED in Issue #16)", () => {
+    expect(
+      VALID_STATUSES.includes("CONFIRMED" as (typeof VALID_STATUSES)[number])
+    ).toBe(false);
+  });
+
+  it("rejects the old SHIPPED status (replaced by ORDERED in Issue #16)", () => {
+    expect(
+      VALID_STATUSES.includes("SHIPPED" as (typeof VALID_STATUSES)[number])
+    ).toBe(false);
+  });
+
+  it("allows PENDING -> BATCHED transition", () => {
     const current = "PENDING";
-    const next = "CONFIRMED";
+    const next = "BATCHED";
     expect(VALID_STATUSES.includes(next)).toBe(true);
     expect(VALID_STATUSES.includes(current)).toBe(true);
   });
 
-  it("allows CONFIRMED -> SHIPPED transition", () => {
-    const next = "SHIPPED";
-    expect(VALID_STATUSES.includes(next)).toBe(true);
+  it("allows BATCHED -> ORDERED -> RECEIVED -> DELIVERED chain", () => {
+    const chain = ["BATCHED", "ORDERED", "RECEIVED", "DELIVERED"] as const;
+    for (const status of chain) {
+      expect(VALID_STATUSES.includes(status)).toBe(true);
+    }
   });
 });

--- a/src/__tests__/email.test.ts
+++ b/src/__tests__/email.test.ts
@@ -50,7 +50,7 @@ const mockOrder: Order = {
   userId: "user-1",
   user: mockUser,
   items: [mockOrderItem],
-  status: "CONFIRMED",
+  status: "BATCHED",
   subtotal: 50.0,
   shippingCost: 0.0,
   tax: 0.0,
@@ -155,9 +155,9 @@ describe("orderConfirmationTemplate", () => {
 // ─── orderStatusTemplate ──────────────────────────────────────────────────────
 
 describe("orderStatusTemplate", () => {
-  it("contains the shipped status label", () => {
-    const html = orderStatusTemplate(mockOrder, "SHIPPED");
-    expect(html).toContain("expédiée");
+  it("contains the ordered status label", () => {
+    const html = orderStatusTemplate(mockOrder, "ORDERED");
+    expect(html).toContain("fournisseur");
   });
 
   it("contains the delivered status label", () => {
@@ -166,13 +166,13 @@ describe("orderStatusTemplate", () => {
   });
 
   it("contains the order id reference", () => {
-    const html = orderStatusTemplate(mockOrder, "SHIPPED");
+    const html = orderStatusTemplate(mockOrder, "ORDERED");
     expect(html).toContain("ABCDEF01");
   });
 
   it("shows tracking number when available", () => {
     const orderWithTracking = { ...mockOrder, trackingNumber: "TRK123456789" };
-    const html = orderStatusTemplate(orderWithTracking, "SHIPPED");
+    const html = orderStatusTemplate(orderWithTracking, "ORDERED");
     expect(html).toContain("TRK123456789");
   });
 });

--- a/src/__tests__/schemas-extended.test.ts
+++ b/src/__tests__/schemas-extended.test.ts
@@ -14,15 +14,15 @@ import {
 describe("orderUpdateSchema", () => {
   it("accepts valid order status update", () => {
     const result = orderUpdateSchema.safeParse({
-      status: "SHIPPED",
+      status: "ORDERED",
       trackingNumber: "TRK123456",
-      notes: "Expédié via Bpost",
+      notes: "Commandé chez Decathlon",
     });
     expect(result.success).toBe(true);
   });
 
   it("accepts minimal update with only status", () => {
-    const result = orderUpdateSchema.safeParse({ status: "CONFIRMED" });
+    const result = orderUpdateSchema.safeParse({ status: "BATCHED" });
     expect(result.success).toBe(true);
   });
 
@@ -31,8 +31,18 @@ describe("orderUpdateSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects the old CONFIRMED status (replaced by BATCHED in Issue #16)", () => {
+    const result = orderUpdateSchema.safeParse({ status: "CONFIRMED" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects the old SHIPPED status (replaced by ORDERED in Issue #16)", () => {
+    const result = orderUpdateSchema.safeParse({ status: "SHIPPED" });
+    expect(result.success).toBe(false);
+  });
+
   it("validates all valid order statuses", () => {
-    const statuses = ["PENDING", "CONFIRMED", "SHIPPED", "DELIVERED", "CANCELLED"];
+    const statuses = ["PENDING", "BATCHED", "ORDERED", "RECEIVED", "DELIVERED", "CANCELLED"];
     for (const status of statuses) {
       const result = orderUpdateSchema.safeParse({ status });
       expect(result.success).toBe(true);
@@ -41,7 +51,7 @@ describe("orderUpdateSchema", () => {
 
   it("accepts empty tracking number string", () => {
     const result = orderUpdateSchema.safeParse({
-      status: "SHIPPED",
+      status: "ORDERED",
       trackingNumber: "",
     });
     expect(result.success).toBe(true);

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -66,7 +66,7 @@ export default function AdminDashboardPage(): React.ReactNode {
   async function handleMarkShipped(order: Order): Promise<void> {
     await updateOrder.mutateAsync({
       id: order.id,
-      data: { status: "SHIPPED" },
+      data: { status: "ORDERED" },
     });
   }
 

--- a/src/app/(admin)/admin/orders/[id]/page.tsx
+++ b/src/app/(admin)/admin/orders/[id]/page.tsx
@@ -131,8 +131,9 @@ export default function AdminOrderDetailPage(): React.ReactNode {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="PENDING">En attente</SelectItem>
-                  <SelectItem value="CONFIRMED">Confirmée</SelectItem>
-                  <SelectItem value="SHIPPED">Expédiée</SelectItem>
+                  <SelectItem value="BATCHED">Groupée</SelectItem>
+                  <SelectItem value="ORDERED">Commandée</SelectItem>
+                  <SelectItem value="RECEIVED">Reçue</SelectItem>
                   <SelectItem value="DELIVERED">Livrée</SelectItem>
                   <SelectItem value="CANCELLED">Annulée</SelectItem>
                 </SelectContent>

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -53,8 +53,9 @@ export default function AdminOrdersPage(): React.ReactNode {
           <SelectContent>
             <SelectItem value="all">Toutes</SelectItem>
             <SelectItem value="PENDING">En attente</SelectItem>
-            <SelectItem value="CONFIRMED">Confirmée</SelectItem>
-            <SelectItem value="SHIPPED">Expédiée</SelectItem>
+            <SelectItem value="BATCHED">Groupée</SelectItem>
+            <SelectItem value="ORDERED">Commandée</SelectItem>
+            <SelectItem value="RECEIVED">Reçue</SelectItem>
             <SelectItem value="DELIVERED">Livrée</SelectItem>
             <SelectItem value="CANCELLED">Annulée</SelectItem>
           </SelectContent>

--- a/src/app/(member)/orders/page.tsx
+++ b/src/app/(member)/orders/page.tsx
@@ -60,8 +60,9 @@ export default function MemberOrdersPage(): React.ReactNode {
           <SelectContent>
             <SelectItem value="all">Toutes</SelectItem>
             <SelectItem value="PENDING">En attente</SelectItem>
-            <SelectItem value="CONFIRMED">Confirmée</SelectItem>
-            <SelectItem value="SHIPPED">Expédiée</SelectItem>
+            <SelectItem value="BATCHED">Groupée</SelectItem>
+            <SelectItem value="ORDERED">Commandée</SelectItem>
+            <SelectItem value="RECEIVED">Reçue</SelectItem>
             <SelectItem value="DELIVERED">Livrée</SelectItem>
             <SelectItem value="CANCELLED">Annulée</SelectItem>
           </SelectContent>

--- a/src/app/api/admin/statistics/route.ts
+++ b/src/app/api/admin/statistics/route.ts
@@ -89,7 +89,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   // Total revenue
   const revenueResult = await prisma.order.aggregate({
     where: {
-      status: { in: ["CONFIRMED", "SHIPPED", "DELIVERED"] },
+      status: { in: ["BATCHED", "ORDERED", "RECEIVED", "DELIVERED"] },
     },
     _sum: { total: true },
   });

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -74,7 +74,8 @@ export async function PATCH(
   const updateData: Record<string, unknown> = { ...parsed.data };
 
   // Set timestamp fields based on status transitions
-  if (parsed.data.status === "SHIPPED" && !existing.shippedAt) {
+  // Note: granular batchedAt / orderedAt / receivedAt columns will be added in sprint 2.
+  if (parsed.data.status === "ORDERED" && !existing.shippedAt) {
     updateData.shippedAt = new Date();
   }
   if (parsed.data.status === "DELIVERED" && !existing.deliveredAt) {

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -35,7 +35,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const take = 20;
   const skip = (page - 1) * take;
 
-  const validStatuses = ["PENDING", "CONFIRMED", "SHIPPED", "DELIVERED", "CANCELLED"] as const;
+  const validStatuses = ["PENDING", "BATCHED", "ORDERED", "RECEIVED", "DELIVERED", "CANCELLED"] as const;
   const statusFilter =
     status && validStatuses.includes(status as (typeof validStatuses)[number])
       ? (status as (typeof validStatuses)[number])

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -66,17 +66,19 @@ async function handleEquipmentOrder(session: Stripe.Checkout.Session): Promise<v
     return;
   }
 
+  // New grouped-orders workflow (Issue #16): the order stays PENDING after payment;
+  // the admin moves it to BATCHED -> ORDERED -> RECEIVED -> DELIVERED. Status is no longer
+  // advanced by the payment event itself, only paidAt is recorded.
   await prisma.order.update({
     where: { id: orderId },
     data: {
-      status: "CONFIRMED",
       paidAt: new Date(),
       stripePaymentIntentId: session.payment_intent as string | null,
     },
   });
 
   try {
-    const fullOrder = { ...order, status: "CONFIRMED" as const, paidAt: new Date() };
+    const fullOrder = { ...order, paidAt: new Date() };
     await sendPaymentConfirmation(fullOrder);
   } catch (err) {
     console.error("[Stripe Webhook] Failed to send payment confirmation email:", err);

--- a/src/components/admin/orders/OrderTable.tsx
+++ b/src/components/admin/orders/OrderTable.tsx
@@ -30,15 +30,20 @@ export function getOrderStatusConfig(status: OrderStatus): {
         label: "En attente",
         className: "bg-amber-500/20 text-amber-400 border-amber-500/30",
       };
-    case "CONFIRMED":
+    case "BATCHED":
       return {
-        label: "Confirmée",
+        label: "Groupée",
         className: "bg-blue-500/20 text-blue-400 border-blue-500/30",
       };
-    case "SHIPPED":
+    case "ORDERED":
       return {
-        label: "Expédiée",
+        label: "Commandée",
         className: "bg-purple-500/20 text-purple-400 border-purple-500/30",
+      };
+    case "RECEIVED":
+      return {
+        label: "Reçue",
+        className: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30",
       };
     case "DELIVERED":
       return {

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -301,7 +301,7 @@ export function orderConfirmationTemplate(order: Order): string {
  * Generates the order status update email HTML template.
  *
  * @param order - The full order object
- * @param status - New order status (e.g. "SHIPPED", "DELIVERED")
+ * @param status - New order status (e.g. "ORDERED", "DELIVERED")
  * @returns Full HTML email string
  */
 /**
@@ -411,14 +411,19 @@ export function membershipPaymentConfirmationTemplate(
 
 export function orderStatusTemplate(order: Order, status: string): string {
   const statusLabels: Record<string, { label: string; description: string; color: string }> = {
-    CONFIRMED: {
-      label: "Commande confirmée",
-      description: "Votre commande a été confirmée et est en cours de préparation.",
+    BATCHED: {
+      label: "Commande groupée",
+      description: "Votre commande a été regroupée avec d'autres et sera passée chez le fournisseur prochainement.",
       color: "#22c55e",
     },
-    SHIPPED: {
-      label: "Commande expédiée",
-      description: "Votre commande est en route ! Vous la recevrez prochainement.",
+    ORDERED: {
+      label: "Commande passée au fournisseur",
+      description: "Le lot a été commandé chez le fournisseur. Vous serez informé(e) à sa réception.",
+      color: PRIMARY_COLOR,
+    },
+    RECEIVED: {
+      label: "Commande reçue",
+      description: "Le lot a été reçu par le club. Distribution à venir.",
       color: PRIMARY_COLOR,
     },
     DELIVERED: {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -158,7 +158,7 @@ export const checkoutSchema = z.object({
  * Zod validation schema for order status updates (admin)
  */
 export const orderUpdateSchema = z.object({
-  status: z.enum(["PENDING", "CONFIRMED", "SHIPPED", "DELIVERED", "CANCELLED"]),
+  status: z.enum(["PENDING", "BATCHED", "ORDERED", "RECEIVED", "DELIVERED", "CANCELLED"]),
   trackingNumber: z.string().optional(),
   notes: z.string().optional(),
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,7 +7,7 @@ export type UserRole = "MEMBER" | "COMMITTEE" | "ADMIN";
 
 export type MembershipStatus = "PENDING" | "ACTIVE" | "INACTIVE" | "EXPIRED";
 
-export type OrderStatus = "PENDING" | "CONFIRMED" | "SHIPPED" | "DELIVERED" | "CANCELLED";
+export type OrderStatus = "PENDING" | "BATCHED" | "ORDERED" | "RECEIVED" | "DELIVERED" | "CANCELLED";
 
 export type EventType = "TRAINING" | "RACE" | "CAMP" | "SOCIAL";
 


### PR DESCRIPTION
## Summary

Sprint 1 d'Issue #16 — pose le socle data + remap du code pour le nouveau workflow de commandes groupées équipement :

```
PENDING → BATCHED → ORDERED → RECEIVED → DELIVERED   (+ CANCELLED)
```

- **Schema** : `OrderStatus` enum remplacé, `Order.batchId String?` ajouté (indexé).
- **Migration** : 1 fichier SQL avec mapping `CONFIRMED→BATCHED`, `SHIPPED→ORDERED` pour rester safe sur les envs non vides.
- **Code** : 16 fichiers remappés mécaniquement (types, Zod, UI selects, OrderTable, statistics, webhook Stripe, email templates).
- **Stripe webhook** : le paiement ne pousse plus le statut — l'order reste `PENDING` jusqu'à action admin. Seul `paidAt` est enregistré. Le timing final paiement (à la commande ou à la livraison) sera tranché par le comité.
- **Tests** : 6 négatifs ajoutés (rejet de `CONFIRMED`/`SHIPPED`), 4 positifs réécrits. **278/278 verts**, build OK, TypeScript clean, ESLint clean.

## Préalable validé

DB prod (`ladtc.be`) interrogée avant migration : **0 commandes**, 12 users, 12 memberships. L'enum peut être remplacé sans risque de migration de données.

## Hors scope (sprint 2)

- Timing du paiement Stripe (décision comité)
- Colonnes timestamp granulaires `batchedAt`, `orderedAt`, `receivedAt`
- UI admin « Commandes en attente » + bouton « Grouper » + page « Lot {id} »
- UI membre : bouton annulation tant que `PENDING`
- Notifications mail aux transitions de statut

## Test plan

- [x] `pnpm exec prisma migrate deploy` passe sur DB locale (0 row → migration triviale)
- [x] `pnpm test` → 278/278 passent
- [x] `pnpm exec tsc --noEmit` → 0 erreur
- [x] `pnpm lint` → 0 erreur (1 warning pré-existant unrelated)
- [x] `pnpm build` → compile OK, 68/68 pages générées
- [ ] À tester en preview Coolify : flux checkout Stripe → vérifier que l'order reste `PENDING` après payment webhook (et que `paidAt` est bien set)
- [ ] À tester en preview Coolify : UI admin affiche bien les nouveaux libellés (Groupée / Commandée / Reçue / Livrée)

Refs: #16