### PR TITLE
fix(docker): entrypoint applies Prisma migrations on startup (#18)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,13 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 
-# Prisma: schema + migrations + self-contained CLI for `prisma migrate deploy`
+# Prisma: schema + migrations + self-contained CLI for `prisma migrate deploy`.
+# The config is required by Prisma 7 (datasource.url comes from env via the config).
+# It sits at /app/prisma.config.ts; the entrypoint exposes prisma-cli/node_modules via
+# NODE_PATH so the config's `import { defineConfig } from "prisma/config"` resolves.
 COPY --from=builder /app/prisma ./prisma
 COPY --from=builder /prisma-cli ./prisma-cli
-# prisma.config.ts must be in the CWD when running prisma CLI
-COPY --from=builder /app/prisma.config.ts ./prisma-cli/prisma.config.ts
+COPY --from=builder /app/prisma.config.ts ./prisma.config.ts
 
 # Entrypoint: runs migrations then starts the server
 COPY docker-entrypoint.sh ./docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
+set -eu
 
 echo "Running Prisma migrations..."
-if [ -f ./prisma-cli/node_modules/.bin/prisma ]; then
-  cd prisma-cli
-  ./node_modules/.bin/prisma migrate deploy --schema ../prisma/schema.prisma 2>&1 || echo "Warning: migration failed, continuing startup"
-  cd ..
-else
-  echo "Prisma CLI not found, skipping migrations"
+PRISMA_BIN="./prisma-cli/node_modules/.bin/prisma"
+
+if [ ! -x "$PRISMA_BIN" ]; then
+  echo "ERROR: Prisma CLI not found at $PRISMA_BIN" >&2
+  exit 1
 fi
+
+# Expose prisma-cli's node_modules so /app/prisma.config.ts can import "prisma/config".
+# The standalone Next.js node_modules at /app/node_modules does not include prisma.
+export NODE_PATH="/app/prisma-cli/node_modules"
+"$PRISMA_BIN" migrate deploy --schema ./prisma/schema.prisma
 
 echo "Starting Next.js server..."
 exec node server.js


### PR DESCRIPTION
## Summary

Fixe le bug latent du Dockerfile qui empêche `prisma migrate deploy` de détecter les migrations au démarrage du container. Découvert après PR #17 où la migration sprint 1 a dû être appliquée à la main sur prod.

## Root cause

L'ancien entrypoint :
\`\`\`sh
cd prisma-cli
./node_modules/.bin/prisma migrate deploy --schema ../prisma/schema.prisma 2>&1 || echo "Warning..."
\`\`\`

Le \`cd prisma-cli\` change le CWD. Le \`prisma.config.ts\` (copié dans \`prisma-cli/\` par le Dockerfile) définit \`migrations.path: "prisma/migrations"\` (relatif). Résultat : Prisma cherche les migrations à \`/app/prisma-cli/prisma/migrations\` (vide) au lieu de \`/app/prisma/migrations\` (rempli).

Le \`|| echo "Warning..."\` masque l'échec → le container démarre quand même → bug invisible.

## Fix

- **Dockerfile** : copie \`prisma.config.ts\` à \`/app/prisma.config.ts\` (pas dans \`prisma-cli/\`)
- **docker-entrypoint.sh** :
  - \`set -eu\` (fail-fast sur erreur)
  - Plus de \`cd prisma-cli\` — exécution depuis \`/app\`
  - \`NODE_PATH=/app/prisma-cli/node_modules\` exposé pour que le config résolve \`import { defineConfig } from "prisma/config"\` (le standalone Next.js de \`/app/node_modules\` ne contient pas prisma)
  - Suppression du \`|| echo "Warning..."\` → une migration ratée fait échouer le container → Coolify marque le deploy comme failed → on le voit

## Validation locale

Image Docker rebuilt + container exécuté contre la DB Postgres locale :

\`\`\`
Loaded Prisma config from prisma.config.ts.
Prisma schema loaded from prisma/schema.prisma.
Datasource "db": PostgreSQL database "ladtc", schema "public" at "db:5432"

14 migrations found in prisma/migrations

No pending migrations to apply.
\`\`\`

À comparer avec le comportement actuel en prod :
\`\`\`
Loaded Prisma config from prisma.config.ts.
Prisma schema loaded from ../prisma/schema.prisma.
Datasource "db": PostgreSQL database "ladtc", schema "public" at "db:5432"

No migration found in prisma/migrations          ← bug

No pending migrations to apply.
\`\`\`

## Effet attendu en prod

- Première migration depuis ce fix : appliquée automatiquement au redeploy
- Une migration ratée fera échouer le deploy Coolify (vs démarrage silencieux avec DB désynchro avant)

## Test plan

- [x] Build Docker local OK
- [x] Container voit les 14 migrations existantes
- [x] \`pnpm test\`, \`pnpm tsc --noEmit\`, \`pnpm lint\`, \`pnpm build\` non-régression (changements purement infra)
- [ ] Après merge : surveiller que le deploy Coolify se passe bien (logs container doivent afficher \`14 migrations found\` ou plus, pas \`No migration found\`)

Closes #18