### PR TITLE
feat(orders): default to club pickup, admin-tunable shipping fee (#16)

### DIFF
--- a/prisma/migrations/20260515094500_default_pickup_and_settings_table/migration.sql
+++ b/prisma/migrations/20260515094500_default_pickup_and_settings_table/migration.sql
@@ -1,0 +1,18 @@
+-- Sprint 2b Issue #16:
+-- 1. Default delivery method becomes CLUB_PICKUP (most common case for the club).
+-- 2. Settings table for admin-tunable values (shipping fee starts here).
+
+ALTER TABLE "Order" ALTER COLUMN "deliveryMethod" SET DEFAULT 'CLUB_PICKUP';
+
+CREATE TABLE "Setting" (
+  "key"       TEXT NOT NULL,
+  "value"     TEXT NOT NULL,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "Setting_pkey" PRIMARY KEY ("key")
+);
+
+-- Seed default: shipping fee for HOME_DELIVERY equipment orders.
+-- Value is JSON-encoded (lib/settings.ts parses on read).
+INSERT INTO "Setting" ("key", "value", "updatedAt")
+VALUES ('equipment.shippingFee', '5.00', NOW());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,6 +132,14 @@ enum DeliveryMethod {
   CLUB_PICKUP
 }
 
+/// Admin-tunable key/value settings. `value` is a JSON-encoded string so it can
+/// hold numbers, booleans, or structured payloads. Read via lib/settings.ts.
+model Setting {
+  key       String   @id
+  value     String
+  updatedAt DateTime @updatedAt
+}
+
 model Product {
   id           String         @id @default(cuid())
   name         String
@@ -166,7 +174,7 @@ model Order {
   userId          String
   user            User           @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  deliveryMethod  DeliveryMethod @default(HOME_DELIVERY)
+  deliveryMethod  DeliveryMethod @default(CLUB_PICKUP)
 
   shippingName    String?
   shippingEmail   String?

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const SHIPPING_FEE_KEY = "equipment.shippingFee";
+
+/**
+ * Admin page for tunable settings.
+ * Only one knob for now (equipment shipping fee). Add new fields here as
+ * settings grow — each key is independent and persisted via PATCH /api/settings/[key].
+ */
+export default function AdminSettingsPage(): React.ReactNode {
+  const [shippingFee, setShippingFee] = useState<string>("");
+  const [initialFee, setInitialFee] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [status, setStatus] = useState<{ kind: "ok" | "error"; message: string } | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/settings/${SHIPPING_FEE_KEY}`)
+      .then((res) => (res.ok ? res.json() : { value: null }))
+      .then((data) => {
+        if (typeof data.value === "number") {
+          setShippingFee(data.value.toFixed(2));
+          setInitialFee(data.value);
+        }
+      })
+      .catch(() => {
+        setStatus({ kind: "error", message: "Impossible de charger la configuration" });
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  async function handleSave(): Promise<void> {
+    setStatus(null);
+    const value = Number(shippingFee.replace(",", "."));
+    if (!Number.isFinite(value) || value < 0) {
+      setStatus({ kind: "error", message: "Le frais doit être un nombre positif ou zéro" });
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const res = await fetch(`/api/settings/${SHIPPING_FEE_KEY}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value }),
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setStatus({ kind: "error", message: body.error ?? "Échec de l'enregistrement" });
+        return;
+      }
+
+      setInitialFee(value);
+      setStatus({ kind: "ok", message: "Configuration enregistrée" });
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const dirty = initialFee !== null && Number(shippingFee.replace(",", ".")) !== initialFee;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10">
+      <h1 className="mb-2 text-3xl font-bold text-foreground">Paramètres</h1>
+      <p className="mb-8 text-sm text-muted-foreground">
+        Valeurs ajustables sans redéploiement. Modifications appliquées immédiatement aux
+        nouvelles commandes.
+      </p>
+
+      <section className="space-y-4 rounded-md border border-border p-6">
+        <h2 className="text-xl font-semibold text-foreground">Équipement — livraison</h2>
+        <p className="text-sm text-muted-foreground">
+          Frais ajoutés à une commande quand le membre choisit la livraison à domicile.
+          Le retrait au club reste gratuit.
+        </p>
+
+        <div className="grid gap-3 sm:grid-cols-[1fr,auto] sm:items-end">
+          <div className="space-y-2">
+            <Label htmlFor="shippingFee">Frais de livraison (€)</Label>
+            <Input
+              id="shippingFee"
+              type="number"
+              step="0.01"
+              min="0"
+              value={shippingFee}
+              onChange={(e) => setShippingFee(e.target.value)}
+              disabled={isLoading || isSaving}
+              placeholder="5.00"
+            />
+          </div>
+          <Button onClick={handleSave} disabled={isLoading || isSaving || !dirty}>
+            {isSaving ? "Enregistrement..." : "Enregistrer"}
+          </Button>
+        </div>
+
+        {status && (
+          <p
+            role={status.kind === "error" ? "alert" : "status"}
+            className={`text-sm ${
+              status.kind === "ok" ? "text-green-500" : "text-destructive"
+            }`}
+          >
+            {status.message}
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(member)/equipment/checkout/page.tsx
+++ b/src/app/(member)/equipment/checkout/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useRequireAuth } from "@/hooks/use-auth";
@@ -12,12 +13,32 @@ import type { CheckoutFormData } from "@/lib/schemas";
 /**
  * Checkout page — shipping form, cart summary, and place order button.
  * Requires authentication.
+ *
+ * Delivery method drives the visible total: CLUB_PICKUP is free, HOME_DELIVERY
+ * adds the admin-configured shipping fee (fetched from /api/settings).
  */
 export default function CheckoutPage(): React.ReactNode {
   const router = useRouter();
   const { isLoading, user } = useRequireAuth();
   const { items, total, clear } = useCart();
   const createOrder = useCreateOrder();
+  const [shippingFee, setShippingFee] = useState<number>(0);
+  const [deliveryMethod, setDeliveryMethod] = useState<"HOME_DELIVERY" | "CLUB_PICKUP">(
+    "CLUB_PICKUP"
+  );
+
+  useEffect(() => {
+    fetch("/api/settings/equipment.shippingFee")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data && typeof data.value === "number") {
+          setShippingFee(data.value);
+        }
+      })
+      .catch(() => {
+        // Silent fallback to 0 — total stays accurate, server is the source of truth at order time
+      });
+  }, []);
 
   if (isLoading) {
     return (
@@ -73,11 +94,14 @@ export default function CheckoutPage(): React.ReactNode {
 
   const defaultValues = user
     ? {
-        deliveryMethod: "HOME_DELIVERY" as const,
+        deliveryMethod: "CLUB_PICKUP" as const,
         shippingName: (user.name as string | undefined) ?? "",
         shippingEmail: user.email,
       }
     : undefined;
+
+  const appliedShipping = deliveryMethod === "HOME_DELIVERY" ? shippingFee : 0;
+  const grandTotal = total + appliedShipping;
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-10">
@@ -91,6 +115,8 @@ export default function CheckoutPage(): React.ReactNode {
             onSubmit={handleSubmit}
             isSubmitting={createOrder.isPending}
             error={createOrder.error?.message}
+            shippingFee={shippingFee}
+            onDeliveryMethodChange={setDeliveryMethod}
           />
         </div>
 
@@ -113,9 +139,23 @@ export default function CheckoutPage(): React.ReactNode {
               </div>
             ))}
           </div>
+          <div className="border-t border-border pt-4 space-y-1 text-sm">
+            <div className="flex justify-between text-muted-foreground">
+              <span>Sous-total</span>
+              <span>{total.toFixed(2)} €</span>
+            </div>
+            <div className="flex justify-between text-muted-foreground">
+              <span>
+                {deliveryMethod === "HOME_DELIVERY" ? "Livraison" : "Retrait au club"}
+              </span>
+              <span>
+                {appliedShipping > 0 ? `${appliedShipping.toFixed(2)} €` : "Gratuit"}
+              </span>
+            </div>
+          </div>
           <div className="border-t border-border pt-4 flex justify-between font-semibold">
             <span>Total</span>
-            <span>{total.toFixed(2)} €</span>
+            <span>{grandTotal.toFixed(2)} €</span>
           </div>
           <p className="text-xs text-muted-foreground">
             Paiement sécurisé par Stripe (carte ou Bancontact).

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -3,6 +3,7 @@ import { requireAuth, isAuthError, COMMITTEE_ROLES } from "@/lib/auth-guard";
 import { prisma } from "@/lib/prisma";
 import { checkoutSchema } from "@/lib/schemas";
 import { getCurrentSeason } from "@/lib/membership";
+import { getEquipmentShippingFee } from "@/lib/settings";
 import { z } from "zod";
 
 const createOrderSchema = checkoutSchema.and(
@@ -170,7 +171,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   });
 
   const subtotal = orderItems.reduce((sum, item) => sum + item.price * item.quantity, 0);
-  const shippingCost = 0;
+  // Shipping fee is admin-tunable via the Setting table. CLUB_PICKUP is always free.
+  const shippingCost =
+    deliveryMethod === "HOME_DELIVERY" ? await getEquipmentShippingFee() : 0;
   const tax = 0;
   const total = subtotal + shippingCost + tax;
 

--- a/src/app/api/settings/[key]/route.ts
+++ b/src/app/api/settings/[key]/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getSettingRaw, setSetting } from "@/lib/settings";
+import { z } from "zod";
+
+const ADMIN_ROLES = ["COMMITTEE", "ADMIN"] as const;
+
+const ALLOWED_KEYS = new Set(["equipment.shippingFee"]);
+
+const updateSchema = z.object({
+  value: z.union([z.number(), z.string(), z.boolean()]),
+});
+
+/**
+ * GET /api/settings/[key]
+ * Returns the current value for a known setting key. Public — values like the
+ * shipping fee need to be visible to logged-in members at checkout time.
+ *
+ * Response: { key, value } where `value` is the decoded JSON or null if unset.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ key: string }> }
+): Promise<NextResponse> {
+  const { key } = await params;
+
+  if (!ALLOWED_KEYS.has(key)) {
+    return NextResponse.json({ error: "Clé inconnue" }, { status: 404 });
+  }
+
+  const raw = await getSettingRaw(key);
+  const value = raw === null ? null : (JSON.parse(raw) as unknown);
+
+  return NextResponse.json({ key, value });
+}
+
+/**
+ * PATCH /api/settings/[key]
+ * Updates the value for a known setting key. Restricted to COMMITTEE and ADMIN.
+ *
+ * Body: { value: number | string | boolean }
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ key: string }> }
+): Promise<NextResponse> {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (!session?.user) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+
+  const userRole = (session.user as { role?: string }).role;
+  if (!ADMIN_ROLES.includes(userRole as (typeof ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: "Accès refusé" }, { status: 403 });
+  }
+
+  const { key } = await params;
+  if (!ALLOWED_KEYS.has(key)) {
+    return NextResponse.json({ error: "Clé inconnue" }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 });
+  }
+
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+
+  // Domain-specific guard: shipping fee must be a non-negative number.
+  if (key === "equipment.shippingFee") {
+    const v = parsed.data.value;
+    if (typeof v !== "number" || v < 0 || !Number.isFinite(v)) {
+      return NextResponse.json(
+        { error: "Le frais de livraison doit être un nombre positif ou zéro" },
+        { status: 422 }
+      );
+    }
+  }
+
+  await setSetting(key, parsed.data.value);
+
+  return NextResponse.json({ key, value: parsed.data.value });
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -22,6 +22,7 @@ const adminNavLinks: NavLink[] = [
   { href: "/admin/statistics", label: "Statistiques", adminOnly: true },
   { href: "/admin/activity-logs", label: "Logs d'activité" },
   { href: "/admin/users", label: "Utilisateurs", adminOnly: true },
+  { href: "/admin/settings", label: "Paramètres" },
 ];
 
 /**

--- a/src/components/forms/CheckoutForm.tsx
+++ b/src/components/forms/CheckoutForm.tsx
@@ -1,17 +1,23 @@
 "use client";
 
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { checkoutSchema, type CheckoutFormData } from "@/lib/schemas";
+import type { DeliveryMethod } from "@/types";
 
 interface CheckoutFormProps {
   defaultValues?: Partial<CheckoutFormData>;
   onSubmit: (data: CheckoutFormData) => Promise<void>;
   isSubmitting?: boolean;
   error?: string;
+  /** Admin-configured fee applied when HOME_DELIVERY is selected. */
+  shippingFee?: number;
+  /** Notifies the parent so it can update the order summary in real time. */
+  onDeliveryMethodChange?: (method: DeliveryMethod) => void;
 }
 
 /**
@@ -25,6 +31,8 @@ export function CheckoutForm({
   onSubmit,
   isSubmitting = false,
   error,
+  shippingFee = 0,
+  onDeliveryMethodChange,
 }: CheckoutFormProps): React.ReactNode {
   const {
     register,
@@ -34,7 +42,7 @@ export function CheckoutForm({
   } = useForm<CheckoutFormData>({
     resolver: zodResolver(checkoutSchema),
     defaultValues: {
-      deliveryMethod: "HOME_DELIVERY",
+      deliveryMethod: "CLUB_PICKUP",
       shippingCountry: "Belgium",
       ...defaultValues,
     },
@@ -43,6 +51,10 @@ export function CheckoutForm({
   const submitting = isSubmitting || formSubmitting;
   const deliveryMethod = watch("deliveryMethod");
   const isHomeDelivery = deliveryMethod === "HOME_DELIVERY";
+
+  useEffect(() => {
+    if (deliveryMethod) onDeliveryMethodChange?.(deliveryMethod);
+  }, [deliveryMethod, onDeliveryMethodChange]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
@@ -55,24 +67,10 @@ export function CheckoutForm({
         </div>
       )}
 
-      {/* Delivery method */}
+      {/* Delivery method — CLUB_PICKUP listed first as the default */}
       <fieldset className="space-y-3">
         <legend className="text-xl font-semibold text-foreground">Mode de livraison</legend>
         <div className="space-y-2">
-          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border p-3 hover:border-primary">
-            <input
-              type="radio"
-              value="HOME_DELIVERY"
-              {...register("deliveryMethod")}
-              className="mt-1"
-            />
-            <div>
-              <p className="font-medium text-foreground">Livraison à domicile</p>
-              <p className="text-sm text-muted-foreground">
-                Réception à l&apos;adresse fournie ci-dessous.
-              </p>
-            </div>
-          </label>
           <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border p-3 hover:border-primary">
             <input
               type="radio"
@@ -80,10 +78,34 @@ export function CheckoutForm({
               {...register("deliveryMethod")}
               className="mt-1"
             />
-            <div>
-              <p className="font-medium text-foreground">Retrait au club</p>
+            <div className="flex-1">
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="font-medium text-foreground">Retrait au club</p>
+                <p className="text-sm font-medium text-green-500">Gratuit</p>
+              </div>
               <p className="text-sm text-muted-foreground">
                 Récupération sur place lors d&apos;une séance — aucune adresse requise.
+              </p>
+            </div>
+          </label>
+          <label className="flex cursor-pointer items-start gap-3 rounded-md border border-border p-3 hover:border-primary">
+            <input
+              type="radio"
+              value="HOME_DELIVERY"
+              {...register("deliveryMethod")}
+              className="mt-1"
+            />
+            <div className="flex-1">
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="font-medium text-foreground">Livraison à domicile</p>
+                {shippingFee > 0 && (
+                  <p className="text-sm font-medium text-foreground">
+                    + {shippingFee.toFixed(2)} €
+                  </p>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Réception à l&apos;adresse fournie ci-dessous.
               </p>
             </div>
           </label>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,59 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Admin-tunable key/value settings backed by the `Setting` table.
+ * Values are JSON-encoded strings on the wire so a single column can hold
+ * numbers, booleans, or structured payloads. Callers are responsible for
+ * declaring the expected runtime type at the call site.
+ *
+ * Known keys (extend this list when adding new settings):
+ *   - "equipment.shippingFee": number (in euros) — fee applied when
+ *     deliveryMethod = HOME_DELIVERY on an equipment order.
+ */
+
+export const SETTING_KEYS = {
+  EQUIPMENT_SHIPPING_FEE: "equipment.shippingFee",
+} as const;
+
+/** Default shipping fee in euros when the Setting row is missing. */
+const DEFAULT_SHIPPING_FEE_EUR = 0;
+
+/**
+ * Reads the raw JSON-encoded value for a setting, returning null if absent.
+ */
+export async function getSettingRaw(key: string): Promise<string | null> {
+  const row = await prisma.setting.findUnique({ where: { key } });
+  return row?.value ?? null;
+}
+
+/**
+ * Reads a numeric setting. Falls back to the provided default when the
+ * setting is absent or malformed.
+ */
+export async function getSettingNumber(key: string, fallback: number): Promise<number> {
+  const raw = await getSettingRaw(key);
+  if (raw === null) return fallback;
+  const parsed = Number(JSON.parse(raw));
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/**
+ * Reads the current shipping fee (in euros) for HOME_DELIVERY equipment orders.
+ * Returns 0 if the setting is absent or unparseable — a missing fee never
+ * inflates an order's total.
+ */
+export async function getEquipmentShippingFee(): Promise<number> {
+  return getSettingNumber(SETTING_KEYS.EQUIPMENT_SHIPPING_FEE, DEFAULT_SHIPPING_FEE_EUR);
+}
+
+/**
+ * Upserts a setting with a JSON-serialised value.
+ */
+export async function setSetting(key: string, value: number | string | boolean): Promise<void> {
+  const encoded = JSON.stringify(value);
+  await prisma.setting.upsert({
+    where: { key },
+    update: { value: encoded },
+    create: { key, value: encoded },
+  });
+}


### PR DESCRIPTION
## Summary

Deux modifs produit cohérentes :

1. **CLUB_PICKUP devient le défaut** — schema + UI alignés (cas le plus courant pour le club).
2. **Frais de livraison admin-configurables** — appliqués à la création de commande quand HOME_DELIVERY est choisi. Stockés dans une table générique \`Setting(key, value)\` pour anticiper d'autres paramètres admin sans migration future.

## Schema

\`\`\`
~ Order.deliveryMethod default: HOME_DELIVERY -> CLUB_PICKUP
+ model Setting { key PK, value, updatedAt }   // value = JSON-encoded string
+ seed equipment.shippingFee = 5.00 EUR
\`\`\`

## Code

- **lib/settings.ts** : helpers typés (\`getSettingRaw\`, \`getSettingNumber\`, \`getEquipmentShippingFee\`, \`setSetting\`) + registry \`SETTING_KEYS\`
- **api/settings/[key]** (nouveau) : GET public, PATCH admin-only, validation domaine (frais ≥ 0)
- **api/orders** : applique \`getEquipmentShippingFee()\` au total si HOME_DELIVERY
- **CheckoutForm** : défaut CLUB_PICKUP, frais affichés inline sur l'option HOME_DELIVERY, callback \`onDeliveryMethodChange\` pour sync parent
- **checkout/page.tsx** : fetch du frais au mount, total live recalculé selon la radio, récap découpé Sous-total / Livraison / Total
- **admin/settings/page.tsx** (nouveau) : UI admin pour ajuster le frais (PATCH direct, feedback inline)
- **AdminNav** : + lien Paramètres

## Test plan

- [x] \`pnpm exec prisma migrate deploy\` (local)
- [x] \`pnpm test\` → 280/280
- [x] \`pnpm exec tsc --noEmit\` → 0 erreur
- [x] \`pnpm lint\` → 0 erreur
- [x] \`pnpm build\` → 69/69 pages
- [ ] Après merge en preview Coolify :
  - [ ] Vérifier que le défaut CLUB_PICKUP s'affiche au checkout
  - [ ] Modifier le frais via /admin/settings et confirmer qu'il s'applique à la commande suivante
  - [ ] Confirmer que CLUB_PICKUP reste à 0,00 € même avec un frais configuré

Refs #16