### PR TITLE
feat(orders): defer payment for grouped orders until batch is received (#16)

### DIFF
--- a/src/app/(member)/equipment/checkout/page.tsx
+++ b/src/app/(member)/equipment/checkout/page.tsx
@@ -70,23 +70,29 @@ export default function CheckoutPage(): React.ReactNode {
     const result = await createOrder.mutateAsync({ ...data, items: orderItems });
     clear();
 
-    // Redirect to Stripe Checkout
-    try {
-      const res = await fetch("/api/stripe/checkout", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ orderId: result.orderId }),
-      });
+    // Payment timing depends on the order status:
+    //   - RECEIVED (in-stock direct sale) → charge immediately via Stripe Checkout
+    //   - PENDING (grouped order) → no payment now; the member will receive a Stripe
+    //     payment link by email when the batch is received at the club
+    const chargesNow = result.order.status === "RECEIVED";
+    if (chargesNow) {
+      try {
+        const res = await fetch("/api/stripe/checkout", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ orderId: result.orderId }),
+        });
 
-      if (res.ok) {
-        const { url } = (await res.json()) as { url: string };
-        if (url) {
-          window.location.href = url;
-          return;
+        if (res.ok) {
+          const { url } = (await res.json()) as { url: string };
+          if (url) {
+            window.location.href = url;
+            return;
+          }
         }
+      } catch {
+        // Stripe unavailable — fallback to classic confirmation
       }
-    } catch {
-      // Stripe unavailable — fallback to classic confirmation
     }
 
     router.push(`/equipment/order/${result.orderId}`);

--- a/src/app/(member)/equipment/order/[id]/page.tsx
+++ b/src/app/(member)/equipment/order/[id]/page.tsx
@@ -138,35 +138,56 @@ function OrderConfirmationContent(): React.ReactNode {
         </div>
       </div>
 
-      {/* Pay now button for unpaid pending orders */}
-      {order.status === "PENDING" && !order.paidAt && (
-        <div className="mt-6">
-          <Button
-            className="w-full sm:w-auto"
-            disabled={payLoading}
-            onClick={async () => {
-              setPayLoading(true);
-              try {
-                const res = await fetch("/api/stripe/checkout", {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({ orderId: order.id }),
-                });
-                if (res.ok) {
-                  const { url } = (await res.json()) as { url: string };
-                  if (url) {
-                    window.location.href = url;
-                    return;
+      {/* Payment trigger — any non-cancelled, non-delivered, unpaid order can be paid.
+          Direct-stock orders (RECEIVED at creation) are paid immediately at checkout,
+          so by the time the member visits this page they will see "déjà payée" instead. */}
+      {!order.paidAt &&
+        order.status !== "CANCELLED" &&
+        order.status !== "DELIVERED" && (
+          <div className="mt-6 space-y-2">
+            {order.status === "PENDING" && (
+              <p className="text-sm text-muted-foreground">
+                Cette commande sera regroupée avec d&apos;autres lors du prochain lot.
+                Vous pourrez la payer maintenant ou attendre la réception du lot.
+              </p>
+            )}
+            {order.status === "RECEIVED" && (
+              <p className="text-sm text-foreground">
+                Le lot est arrivé au club. Merci de régler votre commande.
+              </p>
+            )}
+            <Button
+              className="w-full sm:w-auto"
+              disabled={payLoading}
+              onClick={async () => {
+                setPayLoading(true);
+                try {
+                  const res = await fetch("/api/stripe/checkout", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ orderId: order.id }),
+                  });
+                  if (res.ok) {
+                    const { url } = (await res.json()) as { url: string };
+                    if (url) {
+                      window.location.href = url;
+                      return;
+                    }
                   }
+                } catch {
+                  // Stripe unavailable
                 }
-              } catch {
-                // Stripe unavailable
-              }
-              setPayLoading(false);
-            }}
-          >
-            {payLoading ? "Redirection..." : "Payer maintenant"}
-          </Button>
+                setPayLoading(false);
+              }}
+            >
+              {payLoading ? "Redirection..." : "Payer maintenant"}
+            </Button>
+          </div>
+        )}
+
+      {order.paidAt && order.status !== "DELIVERED" && (
+        <div className="mt-6 rounded-md border border-green-500/30 bg-green-500/10 px-4 py-3 text-sm text-green-500">
+          Commande déjà payée.
         </div>
       )}
 

--- a/src/app/(member)/orders/[id]/page.tsx
+++ b/src/app/(member)/orders/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useRequireAuth } from "@/hooks/use-auth";
@@ -18,6 +19,28 @@ export default function MemberOrderDetailPage(): React.ReactNode {
   const { id } = useParams<{ id: string }>();
   const { isLoading: authLoading } = useRequireAuth();
   const { data, isLoading, isError } = useOrder(id);
+  const [payLoading, setPayLoading] = useState(false);
+
+  async function handlePay(orderId: string): Promise<void> {
+    setPayLoading(true);
+    try {
+      const res = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orderId }),
+      });
+      if (res.ok) {
+        const { url } = (await res.json()) as { url: string };
+        if (url) {
+          window.location.href = url;
+          return;
+        }
+      }
+    } catch {
+      // Stripe unavailable
+    }
+    setPayLoading(false);
+  }
 
   if (authLoading || isLoading) {
     return (
@@ -140,6 +163,38 @@ export default function MemberOrderDetailPage(): React.ReactNode {
           </div>
         )}
       </div>
+
+      {/* Payment trigger for unpaid orders not yet delivered/cancelled */}
+      {!order.paidAt &&
+        order.status !== "CANCELLED" &&
+        order.status !== "DELIVERED" && (
+          <div className="mt-6 space-y-2">
+            {order.status === "PENDING" && (
+              <p className="text-sm text-muted-foreground">
+                Cette commande sera regroupée avec d&apos;autres lors du prochain lot.
+                Le paiement peut être réglé maintenant ou à la réception du lot.
+              </p>
+            )}
+            {order.status === "RECEIVED" && (
+              <p className="text-sm text-foreground">
+                Le lot est arrivé au club. Merci de régler votre commande.
+              </p>
+            )}
+            <Button
+              className="w-full sm:w-auto"
+              disabled={payLoading}
+              onClick={() => handlePay(order.id)}
+            >
+              {payLoading ? "Redirection..." : "Payer maintenant"}
+            </Button>
+          </div>
+        )}
+
+      {order.paidAt && (
+        <div className="mt-6 rounded-md border border-green-500/30 bg-green-500/10 px-4 py-3 text-sm text-green-500">
+          Commande déjà payée.
+        </div>
+      )}
 
       <div className="mt-6">
         <Button variant="outline" asChild>

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth, requireCommittee, isAuthError, COMMITTEE_ROLES } from "@/lib/auth-guard";
 import { prisma } from "@/lib/prisma";
 import { orderUpdateSchema } from "@/lib/schemas";
+import { sendOrderReadyForPayment } from "@/lib/email";
 
 /**
  * GET /api/orders/[id]
@@ -92,6 +93,26 @@ export async function PATCH(
       },
     },
   });
+
+  // Grouped-orders payment trigger: when an order transitions INTO `RECEIVED`
+  // from a different status and is not yet paid, the member receives an email
+  // with a Stripe Checkout link (the order page already exposes a Payer button).
+  // Direct-stock orders (created RECEIVED at checkout time) are excluded — they
+  // have already been paid via Stripe at order creation, so existing.status was
+  // already RECEIVED and we don't re-notify.
+  if (
+    parsed.data.status === "RECEIVED" &&
+    existing.status !== "RECEIVED" &&
+    !existing.paidAt
+  ) {
+    try {
+      await sendOrderReadyForPayment(order);
+    } catch (err) {
+      // Soft failure: the status update is the source of truth, the email is
+      // an outbound side effect that the admin can re-send manually if needed.
+      console.error("[orders] Failed to send 'ready for payment' email", err);
+    }
+  }
 
   return NextResponse.json({ order });
 }

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -305,6 +305,52 @@ export function orderConfirmationTemplate(order: Order): string {
  * @returns Full HTML email string
  */
 /**
+ * Email sent when a grouped order is received at the club and the member can
+ * now pay and pick up. Contains a link to the order page where the member
+ * triggers Stripe Checkout.
+ *
+ * @param order - The full order object with items
+ * @param payUrl - Absolute URL of the member order page (where the "Payer" button lives)
+ * @returns Full HTML email string
+ */
+export function orderReadyForPaymentTemplate(order: Order, payUrl: string): string {
+  const itemList = order.items
+    .map(
+      (item) =>
+        `<li style="margin:4px 0;color:#cbd5e1;">${escapeHtml(item.product.name)}${item.size ? ` (${escapeHtml(item.size)})` : ""} × ${item.quantity}</li>`
+    )
+    .join("");
+
+  const isPickup = order.deliveryMethod === "CLUB_PICKUP";
+  const fulfillmentLine = isPickup
+    ? "Votre commande sera à retirer au club lors d'une prochaine séance."
+    : "Votre commande sera expédiée à l'adresse fournie après réception du paiement.";
+
+  const content = `
+    <h2 style="margin:0 0 16px 0;color:${TEXT_COLOR};font-size:20px;">Votre commande est arrivée</h2>
+    <p style="margin:0 0 16px 0;color:#cbd5e1;line-height:1.6;">
+      Bonne nouvelle : le lot d'équipement contenant votre commande est arrivé au club.
+      Le paiement peut maintenant être finalisé.
+    </p>
+    <div style="background-color:${BACKGROUND_COLOR};border-radius:6px;padding:20px;margin:24px 0;">
+      <p style="margin:0 0 8px 0;color:#94a3b8;font-size:12px;font-weight:bold;text-transform:uppercase;letter-spacing:1px;">
+        Commande #${order.id.slice(-8).toUpperCase()}
+      </p>
+      <ul style="margin:8px 0 0 0;padding-left:18px;">${itemList}</ul>
+      <p style="margin:16px 0 0 0;color:${TEXT_COLOR};font-weight:bold;font-size:16px;">
+        Total à régler : ${order.total.toFixed(2)} EUR
+      </p>
+    </div>
+    <p style="margin:0 0 16px 0;color:#cbd5e1;line-height:1.6;">${fulfillmentLine}</p>
+    ${buttonHtml(payUrl, "Payer ma commande")}
+    <p style="margin:24px 0 0 0;color:#94a3b8;font-size:13px;">
+      Question ? <a href="mailto:${CLUB_EMAIL}" style="color:${PRIMARY_COLOR};">${CLUB_EMAIL}</a>
+    </p>
+  `;
+  return baseTemplate(content);
+}
+
+/**
  * Generates the payment confirmation email HTML template.
  *
  * @param order - The full order object with items

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -5,6 +5,7 @@ import {
   renewalReminderTemplate,
   orderConfirmationTemplate,
   orderStatusTemplate,
+  orderReadyForPaymentTemplate,
   paymentConfirmationTemplate,
   membershipPaymentConfirmationTemplate,
   contactFormTemplate,
@@ -125,6 +126,28 @@ export async function sendOrderStatusUpdate(order: Order, status: string): Promi
 
   // For CLUB_PICKUP orders shippingEmail is null; the buyer's own email is the
   // canonical recipient (it was the source of shippingEmail for HOME_DELIVERY too).
+  const recipient = order.shippingEmail ?? order.user.email;
+  await sendEmail(recipient, subject, html);
+}
+
+/**
+ * Sends an email notifying the member that their grouped equipment order has
+ * been received at the club and is now ready for payment + pickup/delivery.
+ * Includes a link to the order page where they can trigger Stripe Checkout.
+ *
+ * Accepts a relaxed order shape so it can be called from PATCH handlers that
+ * only select id/name/email on the user relation (the template only reads
+ * email and the buyer's name).
+ *
+ * @param order - The order with items + at least { user: { email } }
+ */
+export async function sendOrderReadyForPayment(
+  order: Omit<Order, "user"> & { user: { email: string; name?: string | null } }
+): Promise<void> {
+  const baseUrl = process.env["NEXT_PUBLIC_APP_URL"] ?? "https://ladtc.be";
+  const payUrl = `${baseUrl}/equipment/order/${order.id}`;
+  const subject = `Votre commande LADTC est arrivée — #${order.id.slice(-8).toUpperCase()}`;
+  const html = orderReadyForPaymentTemplate(order as Order, payUrl);
   const recipient = order.shippingEmail ?? order.user.email;
   await sendEmail(recipient, subject, html);
 }


### PR DESCRIPTION
## Summary

Contrainte métier : les commandes groupées d'équipement n'arrivent du fournisseur que **~2 fois par an**. Charger le membre au moment de la commande revient à le faire payer des mois avant qu'il reçoive son article. Cette PR sépare le timing du paiement en deux selon le statut de la commande.

## Workflow

| Cas | Statut à la création | Paiement |
|---|---|---|
| Article en stock | \`RECEIVED\` direct | **Stripe immédiat** (article réservé au club) |
| Commande groupée | \`PENDING\` | **Pas de paiement** à la commande. Email + lien Stripe quand le lot arrive (admin marque RECEIVED) |

Le membre peut aussi **payer en avance** une commande PENDING s'il le souhaite — le bouton « Payer maintenant » est dispo sur sa page de commande tant qu'elle est non payée + non DELIVERED + non CANCELLED.

## Distribution

Décision admin pure, comme convenu : pas de blocage automatique sur \`paidAt\`. L'admin peut marquer DELIVERED librement. Le badge « impayée » reste visible jusqu'à ce que le paiement soit enregistré, ce qui suffit comme signal.

## Code

- **checkout/page.tsx** : ne déclenche Stripe que si \`result.order.status === "RECEIVED"\`. Pour PENDING, redirige vers la page de commande qui contient le bouton de paiement
- **api/orders/[id] PATCH** : à la transition INTO RECEIVED avec \`!paidAt\`, envoi de l'email \`sendOrderReadyForPayment\` (échec silencieux — l'admin peut re-déclencher)
- **lib/email.ts** : nouvelle \`sendOrderReadyForPayment\` avec signature relâchée pour accepter le shape Prisma (id/name/email)
- **lib/email-templates.ts** : nouveau template \`orderReadyForPaymentTemplate\` avec CTA pointant vers la page de commande, copy adaptée HOME_DELIVERY / CLUB_PICKUP
- **member/equipment/order/[id] + member/orders/[id]** : bloc paiement unifié — bouton « Payer maintenant » pour toute commande impayée non DELIVERED/CANCELLED, message adapté au statut (PENDING = paiement anticipé optionnel, RECEIVED = rappel que le lot est arrivé). Badge « Commande déjà payée » quand \`paidAt\` est set

## Test plan

- [x] \`pnpm test\` → 280/280
- [x] \`pnpm tsc --noEmit\` → 0 erreur
- [x] \`pnpm lint\` → 0 erreur
- [x] \`pnpm build\` → 69/69 pages
- [ ] Après merge en preview :
  - [ ] Passer une commande PENDING (article sans stock) → vérifier qu'aucune session Stripe n'est créée, que la page de commande montre « Payer maintenant »
  - [ ] Passer une commande RECEIVED (article en stock après saisie admin via /admin/settings et /api/products/[id]/stock) → vérifier le redirect Stripe immédiat
  - [ ] Marquer une commande PENDING → RECEIVED via PATCH /api/orders/[id] → vérifier l'envoi de l'email \`Votre commande LADTC est arrivée\`
  - [ ] Vérifier l'idempotence : si on remet la commande de RECEIVED → RECEIVED, l'email n'est pas renvoyé

Refs #16