### PR TITLE
feat(orders): batch admin page with bulk transitions + surplus form (#16, sprint 2c.2)

### DIFF
--- a/src/app/(admin)/admin/batches/[batchId]/page.tsx
+++ b/src/app/(admin)/admin/batches/[batchId]/page.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface BatchOrder {
+  id: string;
+  status: string;
+  total: number;
+  deliveryMethod: "HOME_DELIVERY" | "CLUB_PICKUP";
+  paidAt: string | null;
+  user: { id: string; name: string | null; email: string };
+  items: Array<{
+    id: string;
+    quantity: number;
+    size: string | null;
+    price: number;
+    product: { id: string; name: string };
+  }>;
+}
+
+interface BatchDetail {
+  batchId: string;
+  orders: BatchOrder[];
+}
+
+const STATUS_LABELS: Record<string, { label: string; className: string }> = {
+  BATCHED: { label: "Groupée", className: "bg-blue-500/20 text-blue-400 border-blue-500/30" },
+  ORDERED: { label: "Commandée", className: "bg-purple-500/20 text-purple-400 border-purple-500/30" },
+  RECEIVED: { label: "Reçue", className: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30" },
+  DELIVERED: { label: "Livrée", className: "bg-green-500/20 text-green-400 border-green-500/30" },
+  CANCELLED: { label: "Annulée", className: "bg-red-500/20 text-red-400 border-red-500/30" },
+};
+
+interface SurplusKey {
+  productId: string;
+  productName: string;
+  size: string;
+}
+
+export default function BatchDetailPage(): React.ReactNode {
+  const { batchId } = useParams<{ batchId: string }>();
+  const router = useRouter();
+  const [data, setData] = useState<BatchDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isActing, setIsActing] = useState(false);
+  const [showSurplus, setShowSurplus] = useState(false);
+  const [surplus, setSurplus] = useState<Record<string, string>>({});
+
+  async function load(): Promise<void> {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/batches/${batchId}`);
+      if (!res.ok) {
+        setError("Lot introuvable");
+        return;
+      }
+      const body = (await res.json()) as BatchDetail;
+      setData(body);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (batchId) load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [batchId]);
+
+  // Derived: the batch status is the common status across orders; if anything
+  // diverges we surface "Mixte" so the admin notices an inconsistency.
+  const batchStatus = useMemo(() => {
+    if (!data || data.orders.length === 0) return "—";
+    const statuses = new Set(data.orders.map((o) => o.status));
+    return statuses.size === 1 ? data.orders[0].status : "MIXED";
+  }, [data]);
+
+  // Derived: distinct (product, size) pairs in the batch, used to seed the
+  // surplus form. Admin can add extra rows manually but the common case is
+  // surplus on items that were already part of the batch.
+  const surplusKeys: SurplusKey[] = useMemo(() => {
+    if (!data) return [];
+    const map = new Map<string, SurplusKey>();
+    for (const order of data.orders) {
+      for (const item of order.items) {
+        if (!item.size) continue;
+        const key = `${item.product.id}|${item.size}`;
+        if (!map.has(key)) {
+          map.set(key, {
+            productId: item.product.id,
+            productName: item.product.name,
+            size: item.size,
+          });
+        }
+      }
+    }
+    return Array.from(map.values());
+  }, [data]);
+
+  async function transition(
+    target: "ORDERED" | "RECEIVED",
+    surplusPayload?: Array<{ productId: string; size: string; quantity: number }>
+  ): Promise<void> {
+    setIsActing(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/batches/${batchId}/transition`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: target, surplus: surplusPayload }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error ?? "Échec de la transition");
+        return;
+      }
+      setShowSurplus(false);
+      setSurplus({});
+      await load();
+    } finally {
+      setIsActing(false);
+    }
+  }
+
+  function handleReceiveClick(): void {
+    setShowSurplus(true);
+    const initial: Record<string, string> = {};
+    for (const key of surplusKeys) {
+      initial[`${key.productId}|${key.size}`] = "0";
+    }
+    setSurplus(initial);
+  }
+
+  async function handleReceiveSubmit(): Promise<void> {
+    const payload: Array<{ productId: string; size: string; quantity: number }> = [];
+    for (const key of surplusKeys) {
+      const raw = surplus[`${key.productId}|${key.size}`] ?? "0";
+      const value = Number(raw);
+      if (!Number.isInteger(value) || value < 0) {
+        setError(`Surplus invalide pour ${key.productName} (${key.size})`);
+        return;
+      }
+      if (value > 0) {
+        payload.push({ productId: key.productId, size: key.size, quantity: value });
+      }
+    }
+    await transition("RECEIVED", payload.length > 0 ? payload : undefined);
+  }
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-10">
+        <Skeleton className="h-8 w-64 mb-6" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="mx-auto max-w-4xl px-4 py-10 text-center">
+        <p className="text-muted-foreground">{error ?? "Lot introuvable"}</p>
+        <Link href="/admin/batches" className="mt-4 inline-block text-primary hover:underline">
+          Retour aux lots
+        </Link>
+      </div>
+    );
+  }
+
+  const statusConfig =
+    STATUS_LABELS[batchStatus] ?? {
+      label: batchStatus,
+      className: "bg-muted text-muted-foreground",
+    };
+  const totalAmount = data.orders.reduce((sum, o) => sum + o.total, 0);
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10 space-y-8">
+      <div>
+        <Link
+          href="/admin/batches"
+          className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-primary"
+        >
+          ← Retour aux lots
+        </Link>
+        <div className="flex items-baseline justify-between gap-4">
+          <h1 className="text-3xl font-bold text-foreground">
+            Lot <span className="font-mono text-xl text-muted-foreground">{batchId.slice(0, 8)}</span>
+          </h1>
+          <Badge className={`${statusConfig.className} border`}>{statusConfig.label}</Badge>
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {data.orders.length} commande{data.orders.length > 1 ? "s" : ""} —{" "}
+          {totalAmount.toFixed(2)} € au total
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Transition actions */}
+      <section className="rounded-md border border-border p-5 space-y-3">
+        <h2 className="font-semibold text-foreground">Actions</h2>
+        {batchStatus === "BATCHED" && (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Le lot a été regroupé. Quand la commande a été passée chez le fournisseur,
+              cliquer ci-dessous.
+            </p>
+            <Button onClick={() => transition("ORDERED")} disabled={isActing}>
+              {isActing ? "..." : "Marquer commandée"}
+            </Button>
+          </>
+        )}
+
+        {batchStatus === "ORDERED" && !showSurplus && (
+          <>
+            <p className="text-sm text-muted-foreground">
+              Quand le lot arrive du fournisseur, cliquer ci-dessous. Un formulaire permettra de
+              renseigner les éventuels surplus à ajouter au stock.
+            </p>
+            <Button onClick={handleReceiveClick} disabled={isActing}>
+              Marquer reçue…
+            </Button>
+          </>
+        )}
+
+        {batchStatus === "ORDERED" && showSurplus && (
+          <div className="space-y-4">
+            <p className="text-sm text-foreground">
+              Surplus reçus en plus des commandes membres (laisser à 0 si aucun surplus).
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {surplusKeys.map((key) => {
+                const k = `${key.productId}|${key.size}`;
+                return (
+                  <div key={k} className="space-y-1">
+                    <Label htmlFor={`surplus-${k}`}>
+                      {key.productName} — taille {key.size}
+                    </Label>
+                    <Input
+                      id={`surplus-${k}`}
+                      type="number"
+                      min="0"
+                      step="1"
+                      value={surplus[k] ?? "0"}
+                      onChange={(e) =>
+                        setSurplus((prev) => ({ ...prev, [k]: e.target.value }))
+                      }
+                      disabled={isActing}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            <div className="flex gap-3">
+              <Button onClick={handleReceiveSubmit} disabled={isActing}>
+                {isActing ? "..." : "Confirmer réception"}
+              </Button>
+              <Button variant="outline" onClick={() => setShowSurplus(false)} disabled={isActing}>
+                Annuler
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {batchStatus === "RECEIVED" && (
+          <p className="text-sm text-muted-foreground">
+            Lot reçu. Les membres ont été notifiés par email pour régler leur commande. Marquer
+            chaque commande comme livrée individuellement quand elle est remise au membre.
+          </p>
+        )}
+
+        {batchStatus === "DELIVERED" && (
+          <p className="text-sm text-muted-foreground">Toutes les commandes ont été livrées.</p>
+        )}
+
+        {batchStatus === "MIXED" && (
+          <p className="text-sm text-destructive">
+            Les commandes de ce lot ont des statuts différents — vérifier individuellement.
+          </p>
+        )}
+      </section>
+
+      {/* Orders in the batch */}
+      <section className="space-y-3">
+        <h2 className="font-semibold text-foreground">Commandes du lot</h2>
+        <div className="rounded-md border border-border">
+          {data.orders.map((order) => {
+            const orderStatus =
+              STATUS_LABELS[order.status] ?? {
+                label: order.status,
+                className: "bg-muted text-muted-foreground",
+              };
+            return (
+              <Link
+                key={order.id}
+                href={`/admin/orders/${order.id}`}
+                className="flex items-center gap-4 border-b border-border px-4 py-3 last:border-b-0 hover:bg-muted/30"
+                onClick={() => router.prefetch(`/admin/orders/${order.id}`)}
+              >
+                <div className="flex-1">
+                  <p className="font-medium text-foreground">
+                    {order.user.name ?? order.user.email}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {order.items.length} article{order.items.length > 1 ? "s" : ""} —{" "}
+                    {order.total.toFixed(2)} €
+                    {order.deliveryMethod === "CLUB_PICKUP" ? " — retrait club" : " — livraison"}
+                  </p>
+                </div>
+                <Badge className={`${orderStatus.className} border text-xs`}>
+                  {orderStatus.label}
+                </Badge>
+                <span
+                  className={`text-xs ${
+                    order.paidAt ? "text-green-500" : "text-muted-foreground"
+                  }`}
+                >
+                  {order.paidAt ? "Payée" : "Impayée"}
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/batches/page.tsx
+++ b/src/app/(admin)/admin/batches/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface BatchSummary {
+  batchId: string;
+  status: "BATCHED" | "ORDERED" | "RECEIVED" | "DELIVERED" | "CANCELLED";
+  orderCount: number;
+  itemCount: number;
+  total: number;
+  batchedAt: string | null;
+  orderedAt: string | null;
+  receivedAt: string | null;
+  firstOrderAt: string;
+}
+
+interface PendingOrder {
+  id: string;
+  total: number;
+  createdAt: string;
+  user: { name: string | null; email: string };
+  items: Array<{ id: string }>;
+}
+
+const STATUS_LABELS: Record<string, { label: string; className: string }> = {
+  BATCHED: { label: "Groupée", className: "bg-blue-500/20 text-blue-400 border-blue-500/30" },
+  ORDERED: { label: "Commandée", className: "bg-purple-500/20 text-purple-400 border-purple-500/30" },
+  RECEIVED: { label: "Reçue", className: "bg-indigo-500/20 text-indigo-400 border-indigo-500/30" },
+  DELIVERED: { label: "Livrée", className: "bg-green-500/20 text-green-400 border-green-500/30" },
+  CANCELLED: { label: "Annulée", className: "bg-red-500/20 text-red-400 border-red-500/30" },
+};
+
+export default function AdminBatchesPage(): React.ReactNode {
+  const [batches, setBatches] = useState<BatchSummary[]>([]);
+  const [pendingOrders, setPendingOrders] = useState<PendingOrder[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isGrouping, setIsGrouping] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load(): Promise<void> {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [batchesRes, pendingRes] = await Promise.all([
+        fetch("/api/batches"),
+        fetch("/api/orders?status=PENDING"),
+      ]);
+      if (!batchesRes.ok || !pendingRes.ok) {
+        setError("Impossible de charger les lots ou commandes en attente");
+        return;
+      }
+      const batchesBody = (await batchesRes.json()) as { batches: BatchSummary[] };
+      const pendingBody = (await pendingRes.json()) as { orders: PendingOrder[] };
+      setBatches(batchesBody.batches);
+      setPendingOrders(pendingBody.orders);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  function toggle(id: string): void {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function handleGroup(): Promise<void> {
+    if (selected.size === 0) return;
+    setIsGrouping(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/batches", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orderIds: Array.from(selected) }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error ?? "Échec du regroupement");
+        return;
+      }
+      setSelected(new Set());
+      await load();
+    } finally {
+      setIsGrouping(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 space-y-10">
+      <div>
+        <h1 className="text-3xl font-bold text-foreground">Lots d&apos;équipement</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Regrouper les commandes en attente puis piloter les transitions du lot : commande
+          fournisseur, réception, livraison.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {/* Pending orders awaiting a batch */}
+      <section className="space-y-4">
+        <div className="flex items-end justify-between gap-3">
+          <h2 className="text-xl font-semibold text-foreground">
+            Commandes en attente de regroupement
+          </h2>
+          <Button
+            onClick={handleGroup}
+            disabled={selected.size === 0 || isGrouping}
+            size="sm"
+          >
+            {isGrouping
+              ? "Création..."
+              : `Créer un lot${selected.size > 0 ? ` (${selected.size})` : ""}`}
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : pendingOrders.length === 0 ? (
+          <p className="rounded-md border border-border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
+            Aucune commande en attente.
+          </p>
+        ) : (
+          <div className="rounded-md border border-border">
+            {pendingOrders.map((order) => (
+              <label
+                key={order.id}
+                className="flex cursor-pointer items-center gap-4 border-b border-border px-4 py-3 last:border-b-0 hover:bg-muted/30"
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(order.id)}
+                  onChange={() => toggle(order.id)}
+                  className="h-4 w-4"
+                />
+                <div className="flex-1">
+                  <p className="font-medium text-foreground">
+                    {order.user.name ?? order.user.email}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {order.items.length} article{order.items.length > 1 ? "s" : ""} —{" "}
+                    {order.total.toFixed(2)} €
+                  </p>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {new Date(order.createdAt).toLocaleDateString("fr-BE")}
+                </p>
+                <Link
+                  href={`/admin/orders/${order.id}`}
+                  className="text-sm text-primary hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  Détail
+                </Link>
+              </label>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Existing batches */}
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-foreground">Lots</h2>
+
+        {isLoading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : batches.length === 0 ? (
+          <p className="rounded-md border border-border bg-muted/30 px-4 py-6 text-center text-sm text-muted-foreground">
+            Aucun lot pour l&apos;instant.
+          </p>
+        ) : (
+          <div className="rounded-md border border-border">
+            {batches.map((batch) => {
+              const statusConfig =
+                STATUS_LABELS[batch.status] ?? {
+                  label: batch.status,
+                  className: "bg-muted text-muted-foreground",
+                };
+              return (
+                <Link
+                  key={batch.batchId}
+                  href={`/admin/batches/${batch.batchId}`}
+                  className="flex items-center gap-4 border-b border-border px-4 py-3 last:border-b-0 hover:bg-muted/30"
+                >
+                  <div className="flex-1">
+                    <p className="font-mono text-sm text-foreground">
+                      {batch.batchId.slice(0, 8)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {batch.orderCount} commande{batch.orderCount > 1 ? "s" : ""},{" "}
+                      {batch.itemCount} article{batch.itemCount > 1 ? "s" : ""} —{" "}
+                      {batch.total.toFixed(2)} €
+                    </p>
+                  </div>
+                  <Badge className={`${statusConfig.className} border text-xs`}>
+                    {statusConfig.label}
+                  </Badge>
+                  <p className="hidden sm:block text-xs text-muted-foreground">
+                    {batch.batchedAt
+                      ? new Date(batch.batchedAt).toLocaleDateString("fr-BE")
+                      : ""}
+                  </p>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/batches/[batchId]/route.ts
+++ b/src/app/api/batches/[batchId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCommittee, isAuthError } from "@/lib/auth-guard";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/batches/[batchId]
+ * Returns the full detail of a single batch: all orders, members, items, and
+ * the computed batch status. Restricted to COMMITTEE / ADMIN.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ batchId: string }> }
+): Promise<NextResponse> {
+  const authResult = await requireCommittee(request);
+  if (isAuthError(authResult)) return authResult;
+
+  const { batchId } = await params;
+
+  const orders = await prisma.order.findMany({
+    where: { batchId },
+    include: {
+      user: { select: { id: true, name: true, email: true } },
+      items: { include: { product: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (orders.length === 0) {
+    return NextResponse.json({ error: "Lot introuvable" }, { status: 404 });
+  }
+
+  return NextResponse.json({ batchId, orders });
+}

--- a/src/app/api/batches/[batchId]/transition/route.ts
+++ b/src/app/api/batches/[batchId]/transition/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCommittee, isAuthError } from "@/lib/auth-guard";
+import { prisma } from "@/lib/prisma";
+import { sendOrderReadyForPayment } from "@/lib/email";
+import { z } from "zod";
+
+const transitionSchema = z.object({
+  status: z.enum(["ORDERED", "RECEIVED"]),
+  surplus: z
+    .array(
+      z.object({
+        productId: z.string(),
+        size: z.string().min(1),
+        quantity: z.number().int().nonnegative(),
+      })
+    )
+    .optional(),
+});
+
+/**
+ * POST /api/batches/[batchId]/transition
+ * Bulk-transitions all orders in a batch to a new status.
+ * Restricted to COMMITTEE / ADMIN.
+ *
+ * Valid target statuses:
+ *  - ORDERED: marks the batch as placed with the supplier
+ *  - RECEIVED: marks the batch as physically received. Optionally accepts a
+ *    `surplus` payload to credit per-(product, size) excess quantities to the
+ *    ProductStock table in the same transaction. Also triggers the
+ *    "ready for payment" email for unpaid orders in the batch.
+ *
+ * Body:
+ *   { status: "ORDERED" }
+ *   { status: "RECEIVED", surplus?: [{ productId, size, quantity }, ...] }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ batchId: string }> }
+): Promise<NextResponse> {
+  const authResult = await requireCommittee(request);
+  if (isAuthError(authResult)) return authResult;
+
+  const { batchId } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 });
+  }
+
+  const parsed = transitionSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+
+  const { status, surplus } = parsed.data;
+  if (status !== "RECEIVED" && surplus && surplus.length > 0) {
+    return NextResponse.json(
+      { error: "Le surplus n'est applicable qu'à la transition RECEIVED" },
+      { status: 422 }
+    );
+  }
+
+  const orders = await prisma.order.findMany({
+    where: { batchId },
+    select: { id: true, status: true },
+  });
+  if (orders.length === 0) {
+    return NextResponse.json({ error: "Lot introuvable" }, { status: 404 });
+  }
+
+  // Enforce a sane state machine: BATCHED -> ORDERED -> RECEIVED. The PATCH
+  // endpoint stays open for individual exceptions (admin overrides).
+  const expectedCurrent = status === "ORDERED" ? "BATCHED" : "ORDERED";
+  const wrongState = orders.filter((o) => o.status !== expectedCurrent);
+  if (wrongState.length > 0) {
+    return NextResponse.json(
+      {
+        error: `Transition ${expectedCurrent} → ${status} impossible : ${wrongState.length} commande(s) avec un statut différent`,
+      },
+      { status: 409 }
+    );
+  }
+
+  // If admin sent surplus entries, validate they reference real products + sizes.
+  if (surplus && surplus.length > 0) {
+    const productIds = [...new Set(surplus.map((s) => s.productId))];
+    const products = await prisma.product.findMany({
+      where: { id: { in: productIds } },
+      select: { id: true, sizes: true },
+    });
+    const productMap = new Map(products.map((p) => [p.id, p]));
+    for (const entry of surplus) {
+      const product = productMap.get(entry.productId);
+      if (!product) {
+        return NextResponse.json(
+          { error: `Produit ${entry.productId} introuvable dans le surplus` },
+          { status: 422 }
+        );
+      }
+      if (!product.sizes.includes(entry.size)) {
+        return NextResponse.json(
+          { error: `Taille ${entry.size} non disponible pour le produit ${entry.productId}` },
+          { status: 422 }
+        );
+      }
+    }
+  }
+
+  const now = new Date();
+  const timestampField = status === "ORDERED" ? "orderedAt" : "receivedAt";
+
+  await prisma.$transaction(async (tx) => {
+    await tx.order.updateMany({
+      where: { batchId },
+      data: { status, [timestampField]: now },
+    });
+
+    if (status === "RECEIVED" && surplus && surplus.length > 0) {
+      for (const entry of surplus) {
+        if (entry.quantity === 0) continue;
+        await tx.productStock.upsert({
+          where: {
+            productId_size: { productId: entry.productId, size: entry.size },
+          },
+          update: { quantity: { increment: entry.quantity } },
+          create: {
+            productId: entry.productId,
+            size: entry.size,
+            quantity: entry.quantity,
+          },
+        });
+      }
+    }
+  });
+
+  // Side effect: when transitioning INTO RECEIVED, notify unpaid members so
+  // they can settle their order. Soft failure — admin can re-trigger per order.
+  if (status === "RECEIVED") {
+    const unpaidOrders = await prisma.order.findMany({
+      where: { batchId, paidAt: null },
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+        items: { include: { product: true } },
+      },
+    });
+    for (const order of unpaidOrders) {
+      try {
+        await sendOrderReadyForPayment(order);
+      } catch (err) {
+        console.error(
+          `[batches] Failed to send 'ready for payment' email for order ${order.id}`,
+          err
+        );
+      }
+    }
+  }
+
+  return NextResponse.json({ batchId, status, orderCount: orders.length });
+}

--- a/src/app/api/batches/route.ts
+++ b/src/app/api/batches/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCommittee, isAuthError } from "@/lib/auth-guard";
+import { prisma } from "@/lib/prisma";
+import { z } from "zod";
+import { randomUUID } from "node:crypto";
+
+const createBatchSchema = z.object({
+  orderIds: z
+    .array(z.string())
+    .min(1, "Au moins une commande requise pour créer un lot"),
+});
+
+/**
+ * GET /api/batches
+ * Returns aggregated batch summaries. Restricted to COMMITTEE / ADMIN.
+ *
+ * Each row groups orders sharing the same batchId. The batch status is the
+ * status of any order in the group (orders move together via bulk transitions,
+ * so they should always be aligned).
+ */
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authResult = await requireCommittee(request);
+  if (isAuthError(authResult)) return authResult;
+
+  const orders = await prisma.order.findMany({
+    where: { batchId: { not: null } },
+    include: {
+      user: { select: { id: true, name: true, email: true } },
+      items: { select: { id: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const groups = new Map<
+    string,
+    {
+      batchId: string;
+      status: string;
+      orderCount: number;
+      itemCount: number;
+      total: number;
+      batchedAt: Date | null;
+      orderedAt: Date | null;
+      receivedAt: Date | null;
+      firstOrderAt: Date;
+    }
+  >();
+  for (const order of orders) {
+    if (!order.batchId) continue;
+    const existing = groups.get(order.batchId);
+    if (!existing) {
+      groups.set(order.batchId, {
+        batchId: order.batchId,
+        status: order.status,
+        orderCount: 1,
+        itemCount: order.items.length,
+        total: order.total,
+        batchedAt: order.batchedAt,
+        orderedAt: order.orderedAt,
+        receivedAt: order.receivedAt,
+        firstOrderAt: order.createdAt,
+      });
+    } else {
+      existing.orderCount += 1;
+      existing.itemCount += order.items.length;
+      existing.total += order.total;
+      if (order.createdAt < existing.firstOrderAt) existing.firstOrderAt = order.createdAt;
+    }
+  }
+
+  return NextResponse.json({ batches: Array.from(groups.values()) });
+}
+
+/**
+ * POST /api/batches
+ * Groups a set of PENDING orders into a single new batch and transitions them
+ * all to BATCHED in one transaction. Restricted to COMMITTEE / ADMIN.
+ *
+ * Body: { orderIds: string[] }
+ *
+ * Constraints:
+ *  - All orders must exist
+ *  - All orders must currently be PENDING (cannot re-batch already-batched orders)
+ *  - All orders must have no existing batchId
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const authResult = await requireCommittee(request);
+  if (isAuthError(authResult)) return authResult;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Corps de requête invalide" }, { status: 400 });
+  }
+
+  const parsed = createBatchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+
+  const { orderIds } = parsed.data;
+
+  const orders = await prisma.order.findMany({
+    where: { id: { in: orderIds } },
+    select: { id: true, status: true, batchId: true },
+  });
+
+  if (orders.length !== orderIds.length) {
+    return NextResponse.json(
+      { error: "Une ou plusieurs commandes sont introuvables" },
+      { status: 422 }
+    );
+  }
+
+  const invalid = orders.filter((o) => o.status !== "PENDING" || o.batchId !== null);
+  if (invalid.length > 0) {
+    return NextResponse.json(
+      {
+        error: `Commandes non éligibles au regroupement (statut ≠ PENDING ou déjà dans un lot) : ${invalid
+          .map((o) => o.id.slice(-8))
+          .join(", ")}`,
+      },
+      { status: 409 }
+    );
+  }
+
+  const batchId = randomUUID();
+  const now = new Date();
+
+  await prisma.order.updateMany({
+    where: { id: { in: orderIds } },
+    data: { batchId, status: "BATCHED", batchedAt: now },
+  });
+
+  return NextResponse.json({ batchId, orderCount: orderIds.length }, { status: 201 });
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -15,6 +15,7 @@ const adminNavLinks: NavLink[] = [
   { href: "/members", label: "Membres" },
   { href: "/admin/products", label: "Produits" },
   { href: "/admin/orders", label: "Commandes" },
+  { href: "/admin/batches", label: "Lots" },
   { href: "/admin/blog", label: "Blog" },
   { href: "/admin/events", label: "Événements" },
   { href: "/admin/gallery", label: "Galerie" },


### PR DESCRIPTION
## Summary

Ferme le gap UI majeur d'#16 : le workflow grouped-orders devient pilotable de bout en bout depuis l'admin, sans DB direct ni curl.

\`\`\`
PENDING (sélection multiple sur /admin/batches)
   → BATCHED (clic « Créer un lot »)
   → ORDERED (clic « Marquer commandée »)
   → RECEIVED (clic « Marquer reçue… » → formulaire surplus → confirmer)
   → DELIVERED (toujours par commande, via /admin/orders/[id])
\`\`\`

## API

Pas d'entité \`Batch\` (cf. issue #16 « KISS — juste un identifiant partagé »). Le lot est dérivé des commandes qui partagent le même \`batchId\`.

- **POST /api/batches** \`{ orderIds }\` — assigne un nouveau \`batchId\`, transition PENDING → BATCHED, stamp \`batchedAt\`. Valide que toutes les commandes sont PENDING + sans \`batchId\`.
- **GET /api/batches** — listing agrégé (status, count, total, timestamps) calculé in-memory.
- **GET /api/batches/[batchId]** — détail complet (orders + items + members).
- **POST /api/batches/[batchId]/transition** \`{ status: "ORDERED" | "RECEIVED", surplus? }\` — bulk-transition. Le surplus n'est valide qu'avec RECEIVED, payload \`[{ productId, size, quantity }]\` ajouté à \`ProductStock\` dans la même transaction. State machine BATCHED → ORDERED → RECEIVED enforcée.
- Side effect RECEIVED : email \`sendOrderReadyForPayment\` envoyé à chaque commande non payée du lot (soft failure).

## UI

- **/admin/batches** : deux sections — commandes PENDING en attente de regroupement (multi-select + bouton « Créer un lot ») et lots existants (rows cliquables avec status badge).
- **/admin/batches/[batchId]** : détail avec actions contextuelles selon le statut. Le formulaire surplus s'affiche à la transition ORDERED → RECEIVED, pré-rempli avec une ligne par (product, size) présent dans le lot, défaut 0.
- **AdminNav** : + « Lots » entre Commandes et Blog.

## Test plan

- [x] \`pnpm test\` → 280/280
- [x] \`pnpm tsc --noEmit\` → 0 erreur
- [x] \`pnpm build\` → 71/71 pages
- [x] \`pnpm lint\` → 0 erreur
- [ ] Après merge en preview :
  - [ ] Passer 2-3 commandes PENDING différentes
  - [ ] Aller sur /admin/batches → sélectionner les 3 → « Créer un lot » → vérifier transition vers BATCHED + apparition dans « Lots »
  - [ ] Ouvrir le lot → « Marquer commandée » → statut ORDERED, \`orderedAt\` stampé
  - [ ] « Marquer reçue… » → renseigner +2 sur une taille en surplus → confirmer → vérifier que ProductStock.quantity a augmenté de 2, que receivedAt est stampé, et que chaque membre non payé reçoit l'email
  - [ ] Tenter de transitionner un lot déjà RECEIVED → vérifier le 409

Refs #16