### PR TITLE
feat(orders): admin can cancel + hard-delete orders and ungroup + cancel batches (#16)

### DIFF
--- a/src/app/(admin)/admin/batches/[batchId]/page.tsx
+++ b/src/app/(admin)/admin/batches/[batchId]/page.tsx
@@ -130,6 +130,34 @@ export default function BatchDetailPage(): React.ReactNode {
     }
   }
 
+  async function callAction(
+    path: "ungroup" | "cancel",
+    confirmMsg: string,
+    redirectAfter: boolean
+  ): Promise<void> {
+    if (!window.confirm(confirmMsg)) return;
+    setIsActing(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/batches/${batchId}/${path}`, { method: "POST" });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error ?? "Échec de l'action");
+        setIsActing(false);
+        return;
+      }
+      if (redirectAfter) {
+        router.push("/admin/batches");
+      } else {
+        await load();
+        setIsActing(false);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Échec de l'action");
+      setIsActing(false);
+    }
+  }
+
   function handleReceiveClick(): void {
     setShowSurplus(true);
     const initial: Record<string, string> = {};
@@ -291,6 +319,52 @@ export default function BatchDetailPage(): React.ReactNode {
             Les commandes de ce lot ont des statuts différents — vérifier individuellement.
           </p>
         )}
+      </section>
+
+      {/* Danger zone — ungroup / cancel the whole batch */}
+      <section className="rounded-md border border-destructive/30 bg-destructive/5 p-5 space-y-3">
+        <h2 className="font-semibold text-foreground">Actions destructives</h2>
+        <div className="flex flex-wrap gap-3">
+          <Button
+            variant="outline"
+            disabled={batchStatus !== "BATCHED" || isActing}
+            onClick={() =>
+              callAction(
+                "ungroup",
+                `Dégrouper le lot ? Toutes les commandes (${data.orders.length}) repassent en PENDING.`,
+                true
+              )
+            }
+            title={
+              batchStatus !== "BATCHED"
+                ? "Dégroupage uniquement disponible tant que le lot n'a pas été commandé"
+                : undefined
+            }
+          >
+            Dégrouper le lot
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={
+              isActing || batchStatus === "CANCELLED" || batchStatus === "DELIVERED"
+            }
+            onClick={() =>
+              callAction(
+                "cancel",
+                `Annuler l'intégralité du lot ? Toutes les commandes (${data.orders.length}) passent en CANCELLED. Les remboursements éventuels sont à gérer manuellement via Stripe.`,
+                false
+              )
+            }
+          >
+            Annuler le lot entier
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Le dégroupage est possible uniquement tant que le lot n&apos;a pas été commandé
+          chez le fournisseur. L&apos;annulation du lot bascule chaque commande en CANCELLED
+          sans toucher au stock — les commandes payées resteront marquées comme telles, les
+          remboursements éventuels sont à effectuer manuellement via Stripe.
+        </p>
       </section>
 
       {/* Orders in the batch */}

--- a/src/app/(admin)/admin/orders/[id]/page.tsx
+++ b/src/app/(admin)/admin/orders/[id]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useOrder, useUpdateOrder } from "@/hooks/use-orders";
@@ -26,8 +27,45 @@ import type { OrderStatus } from "@/types";
  */
 export default function AdminOrderDetailPage(): React.ReactNode {
   const { id } = useParams<{ id: string }>();
+  const router = useRouter();
   const { data, isLoading, isError } = useOrder(id);
   const updateOrder = useUpdateOrder();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  async function handleCancel(): Promise<void> {
+    if (!window.confirm("Annuler cette commande ? Le statut passera à CANCELLED.")) return;
+    setActionError(null);
+    try {
+      await updateOrder.mutateAsync({ id, data: { status: "CANCELLED" } });
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Échec de l'annulation");
+    }
+  }
+
+  async function handleHardDelete(): Promise<void> {
+    if (
+      !window.confirm(
+        "Supprimer définitivement la commande ? Cette action est irréversible. Le stock direct sera restauré automatiquement."
+      )
+    )
+      return;
+    setActionError(null);
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/orders/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setActionError(body.error ?? "Échec de la suppression");
+        setIsDeleting(false);
+        return;
+      }
+      router.push("/admin/orders");
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Échec de la suppression");
+      setIsDeleting(false);
+    }
+  }
 
   const {
     register,
@@ -224,6 +262,45 @@ export default function AdminOrderDetailPage(): React.ReactNode {
             <p>{order.shippingEmail}</p>
           </address>
         )}
+      </div>
+
+      {/* Danger zone */}
+      <div className="mt-8 rounded-md border border-destructive/30 bg-destructive/5 p-5">
+        <h2 className="mb-3 font-semibold text-foreground">Actions sur la commande</h2>
+        {actionError && (
+          <p role="alert" className="mb-3 text-sm text-destructive">
+            {actionError}
+          </p>
+        )}
+        <div className="flex flex-wrap gap-3">
+          <Button
+            variant="outline"
+            onClick={handleCancel}
+            disabled={
+              order.status === "CANCELLED" || updateOrder.isPending || isDeleting
+            }
+          >
+            Annuler la commande
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleHardDelete}
+            disabled={order.paidAt !== null || isDeleting}
+            title={
+              order.paidAt
+                ? "Impossible de supprimer une commande payée (préserver la traçabilité)"
+                : undefined
+            }
+          >
+            {isDeleting ? "Suppression..." : "Supprimer définitivement"}
+          </Button>
+        </div>
+        <p className="mt-3 text-xs text-muted-foreground">
+          L&apos;annulation préserve l&apos;historique (statut CANCELLED). La suppression
+          efface définitivement la commande et restaure le stock pour les ventes directes
+          non payées. Une commande payée ne peut pas être supprimée — l&apos;annuler à la
+          place.
+        </p>
       </div>
     </div>
   );

--- a/src/app/api/batches/[batchId]/cancel/route.ts
+++ b/src/app/api/batches/[batchId]/cancel/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCommittee, isAuthError } from "@/lib/auth-guard";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * POST /api/batches/[batchId]/cancel
+ * Cancels every order in the batch (status → CANCELLED). Restricted to
+ * COMMITTEE / ADMIN.
+ *
+ * No stock action: batched orders never decremented stock at creation, so
+ * cancelling them does not restore anything. Direct-stock cancellations go
+ * through PATCH /api/orders/[id] which handles the per-order stock restore.
+ *
+ * Already-paid orders are NOT excluded — the admin sees the paidAt flag and
+ * decides; refunds happen out-of-band via Stripe and are out of scope here.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ batchId: string }> }
+): Promise<NextResponse> {
+  const authResult = await requireCommittee(request);
+  if (isAuthError(authResult)) return authResult;
+
+  const { batchId } = await params;
+
+  const orders = await prisma.order.findMany({
+    where: { batchId },
+    select: { id: true, status: true, paidAt: true },
+  });
+  if (orders.length === 0) {
+    return NextResponse.json({ error: "Lot introuvable" }, { status: 404 });
+  }
+
+  await prisma.order.updateMany({
+    where: { batchId },
+    data: { status: "CANCELLED" },
+  });
+
+  const paidCount = orders.filter((o) => o.paidAt !== null).length;
+
+  return NextResponse.json({
+    batchId,
+    orderCount: orders.length,
+    paidCount,
+    action: "cancelled",
+  });
+}

--- a/src/app/api/batches/[batchId]/ungroup/route.ts
+++ b/src/app/api/batches/[batchId]/ungroup/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireCommittee, isAuthError } from "@/lib/auth-guard";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * POST /api/batches/[batchId]/ungroup
+ * Dissolves a batch that has not been ordered with the supplier yet: every
+ * order in the batch loses its batchId, reverts to status PENDING, and its
+ * batchedAt timestamp is cleared. Restricted to COMMITTEE / ADMIN.
+ *
+ * Refused if any order is past BATCHED — once the lot has been ordered,
+ * received, etc., it cannot be unmade without manual intervention.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ batchId: string }> }
+): Promise<NextResponse> {
+  const authResult = await requireCommittee(request);
+  if (isAuthError(authResult)) return authResult;
+
+  const { batchId } = await params;
+
+  const orders = await prisma.order.findMany({
+    where: { batchId },
+    select: { id: true, status: true },
+  });
+  if (orders.length === 0) {
+    return NextResponse.json({ error: "Lot introuvable" }, { status: 404 });
+  }
+
+  const notBatched = orders.filter((o) => o.status !== "BATCHED");
+  if (notBatched.length > 0) {
+    return NextResponse.json(
+      {
+        error: `Dégroupage impossible : ${notBatched.length} commande(s) déjà au-delà de BATCHED. Le lot a déjà avancé dans le workflow.`,
+      },
+      { status: 409 }
+    );
+  }
+
+  await prisma.order.updateMany({
+    where: { batchId },
+    data: { batchId: null, status: "PENDING", batchedAt: null },
+  });
+
+  return NextResponse.json({ batchId, orderCount: orders.length, action: "ungrouped" });
+}

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -90,15 +90,39 @@ export async function PATCH(
     updateData.deliveredAt = now;
   }
 
-  const order = await prisma.order.update({
-    where: { id },
-    data: updateData,
-    include: {
-      user: { select: { id: true, name: true, email: true } },
-      items: {
-        include: { product: true },
+  // Direct-stock cancel: if a member's order was fulfilled from existing stock
+  // (created with status RECEIVED, no batch) and the admin now cancels it,
+  // restore the items to ProductStock so they can be sold again. Batched
+  // orders never decremented stock at creation, so no restoration is needed
+  // for them.
+  const restoreStock =
+    parsed.data.status === "CANCELLED" &&
+    existing.status === "RECEIVED" &&
+    existing.batchId === null;
+
+  const order = await prisma.$transaction(async (tx) => {
+    if (restoreStock) {
+      const itemsToRestore = await tx.orderItem.findMany({
+        where: { orderId: id },
+        select: { productId: true, size: true, quantity: true },
+      });
+      for (const item of itemsToRestore) {
+        if (!item.size) continue;
+        await tx.productStock.upsert({
+          where: { productId_size: { productId: item.productId, size: item.size } },
+          update: { quantity: { increment: item.quantity } },
+          create: { productId: item.productId, size: item.size, quantity: item.quantity },
+        });
+      }
+    }
+    return tx.order.update({
+      where: { id },
+      data: updateData,
+      include: {
+        user: { select: { id: true, name: true, email: true } },
+        items: { include: { product: true } },
       },
-    },
+    });
   });
 
   // Grouped-orders payment trigger: when an order transitions INTO `RECEIVED`
@@ -122,4 +146,62 @@ export async function PATCH(
   }
 
   return NextResponse.json({ order });
+}
+
+/**
+ * DELETE /api/orders/[id]
+ * Hard-deletes an order. Restricted to COMMITTEE / ADMIN.
+ *
+ * Refused when the order has been paid (paidAt is set) — paid orders must be
+ * kept for financial traceability. The admin can soft-cancel them instead via
+ * PATCH with status: CANCELLED.
+ *
+ * Direct-stock orders (status RECEIVED, no batchId) have their items restored
+ * to ProductStock before deletion. OrderItem rows cascade thanks to onDelete.
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<NextResponse> {
+  const authResult = await requireCommittee(request);
+  if (isAuthError(authResult)) return authResult;
+
+  const { id } = await params;
+
+  const existing = await prisma.order.findUnique({
+    where: { id },
+    include: { items: { select: { productId: true, size: true, quantity: true } } },
+  });
+  if (!existing) {
+    return NextResponse.json({ error: "Commande introuvable" }, { status: 404 });
+  }
+
+  if (existing.paidAt) {
+    return NextResponse.json(
+      {
+        error:
+          "Impossible de supprimer une commande payée — utiliser l'annulation pour préserver la traçabilité financière",
+      },
+      { status: 409 }
+    );
+  }
+
+  const restoreStock =
+    existing.status === "RECEIVED" && existing.batchId === null;
+
+  await prisma.$transaction(async (tx) => {
+    if (restoreStock) {
+      for (const item of existing.items) {
+        if (!item.size) continue;
+        await tx.productStock.upsert({
+          where: { productId_size: { productId: item.productId, size: item.size } },
+          update: { quantity: { increment: item.quantity } },
+          create: { productId: item.productId, size: item.size, quantity: item.quantity },
+        });
+      }
+    }
+    await tx.order.delete({ where: { id } });
+  });
+
+  return NextResponse.json({ success: true, stockRestored: restoreStock });
 }


### PR DESCRIPTION
## Summary

4 actions destructives ajoutées sur orders + batches, chacune avec sa propre sémantique.

| Action | Endpoint | Sémantique | Refus si |
|---|---|---|---|
| Annuler une commande | \`PATCH /api/orders/[id]\` body \`{status: "CANCELLED"}\` | Soft cancel, historique préservé | — |
| Supprimer une commande | \`DELETE /api/orders/[id]\` | Hard delete, cascade OrderItems | \`paidAt\` set (traçabilité financière) |
| Dégrouper un lot | \`POST /api/batches/[batchId]/ungroup\` | Toutes les commandes → PENDING, batchId+batchedAt vidés | Toute commande au-delà de BATCHED |
| Annuler un lot | \`POST /api/batches/[batchId]/cancel\` | Toutes les commandes → CANCELLED | — |

## Restauration du stock

L'annulation et la suppression d'une commande **directe-stock** (status RECEIVED + pas de batchId) re-incrémentent `ProductStock` pour chaque item. Les commandes batched ne touchent pas au stock à la création donc rien à restaurer.

## UI

- **\`/admin/orders/[id]\`** : danger zone avec « Annuler » (toujours sauf déjà CANCELLED) et « Supprimer définitivement » (désactivé si payée + tooltip). Confirmations explicites.
- **\`/admin/batches/[batchId]\`** : danger zone avec « Dégrouper le lot » (uniquement BATCHED) et « Annuler le lot entier » (toujours sauf CANCELLED/DELIVERED). Confirmations détaillées sur impact.

State machine enforcée côté serveur — l'UI désactive les actions invalides mais l'API reste source de vérité.

## Test plan

- [x] \`pnpm test\` → 280/280
- [x] \`pnpm tsc --noEmit\` → 0 erreur
- [x] \`pnpm build\` → 71/71 pages
- [x] \`pnpm lint\` → 0 erreur
- [ ] Après merge en preview :
  - [ ] Commande directe-stock non payée → « Supprimer » → vérifier que la ligne disparaît et que ProductStock a été ré-incrémenté
  - [ ] Commande payée → « Supprimer » → vérifier 409 « préserver la traçabilité »
  - [ ] Lot BATCHED → « Dégrouper » → vérifier que les commandes repassent PENDING + batchId null
  - [ ] Lot ORDERED → « Dégrouper » → vérifier 409 « déjà au-delà de BATCHED »
  - [ ] Lot quelconque → « Annuler le lot entier » → toutes commandes en CANCELLED

Refs #16