### PR TITLE
fix(stripe): checkout endpoint accepts non-PENDING unpaid orders

### DIFF
--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -39,10 +39,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Non autorisé" }, { status: 403 });
   }
 
-  if (order.status !== "PENDING") {
-    return NextResponse.json({ error: "Cette commande n'est plus en attente" }, { status: 400 });
+  // Any non-cancelled, non-delivered, unpaid order can trigger a Stripe Checkout.
+  // - PENDING: grouped order, member chooses to pay early (or wait for the lot).
+  // - BATCHED / ORDERED: lot in progress, member can pay anytime once decided.
+  // - RECEIVED: direct-stock sale at order creation, OR a batched order whose lot
+  //   has arrived at the club and is now collectable.
+  if (order.status === "CANCELLED") {
+    return NextResponse.json({ error: "Cette commande a été annulée" }, { status: 400 });
   }
-
+  if (order.status === "DELIVERED") {
+    return NextResponse.json({ error: "Cette commande a déjà été livrée" }, { status: 400 });
+  }
   if (order.paidAt) {
     return NextResponse.json({ error: "Cette commande a déjà été payée" }, { status: 400 });
   }


### PR DESCRIPTION
## Hotfix — débloque la migration Stripe en cours de test

Régression introduite par #16 sprint 1/2 : quand les commandes direct-stock ont commencé à partir en statut \`RECEIVED\` à la création (et les grouped en \`PENDING\`), l'endpoint \`/api/stripe/checkout\` a gardé sa guard d'origine qui n'accepte que \`PENDING\`.

Résultat : impossible de payer une commande direct-stock ni une RECEIVED-via-batch dès qu'on clique « Payer maintenant ». 400 « Cette commande n'est plus en attente » silencieux.

## Fix

Remplacer la guard stricte par la même policy que dans l'UI :

\`\`\`ts
if (order.status === "CANCELLED") return reject;
if (order.status === "DELIVERED") return reject;
if (order.paidAt) return reject;
// tout le reste : autoriser
\`\`\`

## Test plan

- [x] \`pnpm test\` → 280/280
- [x] \`pnpm tsc --noEmit\` → 0 erreur
- [ ] Après merge en prod : retester la commande RECEIVED direct-stock du test de migration Stripe → doit cette fois rediriger vers Stripe Checkout

Refs #16