### PR TITLE
fix(membership): MembershipCard checks status === ACTIVE, not just season

### DIFF
--- a/src/components/cards/MembershipCard.tsx
+++ b/src/components/cards/MembershipCard.tsx
@@ -51,7 +51,12 @@ export function MembershipCard({ membership }: MembershipCardProps): React.React
   }
 
   const statusConfig = getMembershipStatusConfig(membership.status);
-  const paidForCurrentSeason = isSeasonCurrent(membership.season);
+  // A membership counts as "paid for the current season" only when its season
+  // matches AND its status is ACTIVE. A PENDING membership for the current
+  // season is awaiting payment, not paid (same policy as the orders API,
+  // which only accepts active members for cotisation-current-season).
+  const paidForCurrentSeason =
+    isSeasonCurrent(membership.season) && membership.status === "ACTIVE";
   const currentSeason = getCurrentSeason();
 
   return (


### PR DESCRIPTION
## Bug

Découvert pendant le test de la migration Stripe le 2026-05-15. Une Membership avec `status=PENDING` et `season='2025-2026'` s'affichait comme « Cotisation à jour pour la 2025-2026 » sans bouton « Payer en ligne ». Comportement inverse de l'intention.

## Root cause

Ligne 54 de `MembershipCard.tsx` :

\`\`\`ts
const paidForCurrentSeason = isSeasonCurrent(membership.season);
\`\`\`

Ne vérifie QUE la saison, jamais le statut.

## Fix

\`\`\`ts
const paidForCurrentSeason =
  isSeasonCurrent(membership.season) && membership.status === "ACTIVE";
\`\`\`

Cohérent avec la policy de l'API orders (\`/api/orders\` n'autorise les commandes que pour \`status === "ACTIVE"\` et season courante).

## Test plan

- [x] \`pnpm test\` → 280/280
- [x] \`pnpm tsc --noEmit\` → 0 erreur
- [x] \`pnpm build\` → 71/71 pages
- [ ] Après merge en prod : créer un membre test PENDING, vérifier que le bouton « Payer en ligne » apparaît bien sur sa page profil