### PR TITLE
feat(blog): support self-hosted MP4 videos in blog content

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,6 +25,7 @@ const nextConfig: NextConfig = {
             "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
             "style-src 'self' 'unsafe-inline'",
             "img-src 'self' data: blob: https://ladtc.be https:",
+            "media-src 'self'",
             "font-src 'self'",
             "connect-src 'self' https://*.sentry.io",
             "frame-src https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com",

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -109,6 +109,62 @@ describe("Video embed support in blog content", () => {
   });
 });
 
+// ─── Self-hosted <video> sanitization ───────────────────────────────────────
+
+describe("Self-hosted video support in blog content", () => {
+  it("auto-embeds bare local MP4 paths as a <video> player", () => {
+    const md = "# Sortie club\n\n/uploads/blog/sortie-trail.mp4\n\nText after.";
+    const html = renderBlogContent(md);
+    expect(html).toContain("<video");
+    expect(html).toContain('src="/uploads/blog/sortie-trail.mp4"');
+    expect(html).toContain("controls");
+    expect(html).toContain('preload="metadata"');
+    expect(html).toContain("Text after.");
+  });
+
+  it("preserves raw <video> tags pointing to local uploads", () => {
+    const md = '<video src="/uploads/blog/clip.mp4" controls></video>';
+    const html = renderBlogContent(md);
+    expect(html).toContain('src="/uploads/blog/clip.mp4"');
+  });
+
+  it("strips <video> tags pointing to external hosts", () => {
+    const md = '<video src="https://evil.com/payload.mp4" controls></video><p>Safe</p>';
+    const html = renderBlogContent(md);
+    expect(html).not.toContain("evil.com");
+    expect(html).not.toContain("<video");
+    expect(html).toContain("Safe");
+  });
+
+  it("strips <video> tags with an external <source> child", () => {
+    const md =
+      '<video controls><source src="https://evil.com/payload.mp4" type="video/mp4"></video>';
+    const html = renderBlogContent(md);
+    expect(html).not.toContain("evil.com");
+    expect(html).not.toContain("<video");
+  });
+
+  it("strips <video> tags with no source at all", () => {
+    const md = "<video controls></video><p>Safe</p>";
+    const html = renderBlogContent(md);
+    expect(html).not.toContain("<video");
+    expect(html).toContain("Safe");
+  });
+
+  it("removes autoplay from local videos", () => {
+    const md = '<video src="/uploads/blog/clip.mp4" autoplay controls></video>';
+    const html = renderBlogContent(md);
+    expect(html).toContain("<video");
+    expect(html).not.toContain("autoplay");
+  });
+
+  it("does not embed external MP4 URLs written as bare text", () => {
+    const md = "https://evil.com/payload.mp4";
+    const html = renderBlogContent(md);
+    expect(html).not.toContain("<video");
+  });
+});
+
 // ─── CSP headers configuration ──────────────────────────────────────────────
 
 describe("CSP headers in next.config", () => {
@@ -117,6 +173,7 @@ describe("CSP headers in next.config", () => {
     "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https://ladtc.be https:",
+    "media-src 'self'",
     "font-src 'self'",
     "connect-src 'self' https://*.sentry.io",
     "frame-src https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com",
@@ -136,6 +193,10 @@ describe("CSP headers in next.config", () => {
     expect(cspValue).toContain("frame-src https://www.youtube.com");
     expect(cspValue).toContain("https://www.youtube-nocookie.com");
     expect(cspValue).toContain("https://player.vimeo.com");
+  });
+
+  it("restricts media sources to self only", () => {
+    expect(cspValue).toContain("media-src 'self'");
   });
 
   it("allows connections to Sentry for error tracking", () => {

--- a/src/__tests__/uploads-route.test.ts
+++ b/src/__tests__/uploads-route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, writeFile, rm } from "fs/promises";
+import { join } from "path";
+import { NextRequest } from "next/server";
+import { GET, HEAD } from "@/app/uploads/[...path]/route";
+
+// ─── Runtime uploads route handler ──────────────────────────────────────────
+
+const TEST_DIR = join(process.cwd(), "public", "uploads", "__test__");
+const TEST_CONTENT = "0123456789abcdef"; // 16 bytes — easy range math
+
+function makeParams(segments: string[]): { params: Promise<{ path: string[] }> } {
+  return { params: Promise.resolve({ path: segments }) };
+}
+
+function makeRequest(range?: string): NextRequest {
+  return new NextRequest("http://localhost/uploads/__test__/file.mp4", {
+    headers: range ? { range } : undefined,
+  });
+}
+
+describe("Uploads route handler (runtime files)", () => {
+  beforeAll(async () => {
+    await mkdir(TEST_DIR, { recursive: true });
+    await writeFile(join(TEST_DIR, "file.mp4"), TEST_CONTENT);
+    await writeFile(join(TEST_DIR, "script.sh"), "#!/bin/sh");
+  });
+
+  afterAll(async () => {
+    await rm(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("serves an existing file with correct headers", async () => {
+    const res = await GET(makeRequest(), makeParams(["__test__", "file.mp4"]));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("video/mp4");
+    expect(res.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(res.headers.get("Content-Length")).toBe(String(TEST_CONTENT.length));
+    expect(await res.text()).toBe(TEST_CONTENT);
+  });
+
+  it("returns 404 for a missing file", async () => {
+    const res = await GET(makeRequest(), makeParams(["__test__", "nope.mp4"]));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a disallowed extension", async () => {
+    const res = await GET(makeRequest(), makeParams(["__test__", "script.sh"]));
+    expect(res.status).toBe(404);
+  });
+
+  it("blocks path traversal outside the uploads directory", async () => {
+    const res = await GET(makeRequest(), makeParams(["..", "..", "package.json"]));
+    expect(res.status).toBe(404);
+  });
+
+  it("serves partial content for a valid Range request", async () => {
+    const res = await GET(makeRequest("bytes=0-3"), makeParams(["__test__", "file.mp4"]));
+    expect(res.status).toBe(206);
+    expect(res.headers.get("Content-Range")).toBe(`bytes 0-3/${TEST_CONTENT.length}`);
+    expect(res.headers.get("Content-Length")).toBe("4");
+    expect(await res.text()).toBe("0123");
+  });
+
+  it("serves an open-ended Range to end of file", async () => {
+    const res = await GET(makeRequest("bytes=10-"), makeParams(["__test__", "file.mp4"]));
+    expect(res.status).toBe(206);
+    expect(await res.text()).toBe("abcdef");
+  });
+
+  it("returns 416 for an out-of-bounds Range", async () => {
+    const res = await GET(makeRequest("bytes=100-200"), makeParams(["__test__", "file.mp4"]));
+    expect(res.status).toBe(416);
+    expect(res.headers.get("Content-Range")).toBe(`bytes */${TEST_CONTENT.length}`);
+  });
+
+  it("answers HEAD with headers and no body", async () => {
+    const res = await HEAD(makeRequest(), makeParams(["__test__", "file.mp4"]));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Length")).toBe(String(TEST_CONTENT.length));
+    expect(res.body).toBeNull();
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,3 +151,13 @@
   height: 100%;
   border: 0;
 }
+
+/* Self-hosted <video> player in blog content (keeps native aspect ratio) */
+.video-player {
+  display: block;
+  width: 100%;
+  max-height: 80vh;
+  margin: 1.5rem 0;
+  border-radius: var(--radius);
+  background-color: #000;
+}

--- a/src/app/uploads/[...path]/route.ts
+++ b/src/app/uploads/[...path]/route.ts
@@ -1,0 +1,130 @@
+import { createReadStream } from "fs";
+import { stat } from "fs/promises";
+import { join, normalize, sep } from "path";
+import { Readable } from "stream";
+import type { NextRequest } from "next/server";
+
+/**
+ * Serves files uploaded at runtime (Docker volume).
+ *
+ * Next.js only serves `public/` assets present at build time — files written
+ * after the build (admin uploads, scp'd videos) are invisible to the static
+ * handler and would 404. This route streams them from disk instead, with
+ * HTTP Range support so <video> seeking works.
+ */
+
+const UPLOAD_DIR = join(process.cwd(), "public", "uploads");
+
+/** Allowed extensions → Content-Type. Anything else 404s. */
+const MIME_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+  gif: "image/gif",
+  mp4: "video/mp4",
+  pdf: "application/pdf",
+};
+
+interface ResolvedFile {
+  filePath: string;
+  mimeType: string;
+  size: number;
+}
+
+/**
+ * Resolve and validate a requested upload path.
+ * Returns null when the path escapes UPLOAD_DIR (traversal), has a
+ * disallowed extension, or does not exist on disk.
+ */
+async function resolveUpload(segments: string[]): Promise<ResolvedFile | null> {
+  const filePath = normalize(join(UPLOAD_DIR, ...segments));
+
+  // Path traversal guard: the resolved path must stay inside UPLOAD_DIR
+  if (!filePath.startsWith(UPLOAD_DIR + sep)) return null;
+
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  const mimeType = MIME_TYPES[ext];
+  if (!mimeType) return null;
+
+  try {
+    const stats = await stat(filePath);
+    if (!stats.isFile()) return null;
+    return { filePath, mimeType, size: stats.size };
+  } catch {
+    return null; // missing file
+  }
+}
+
+/** Common headers for both full and partial responses. */
+function baseHeaders(file: ResolvedFile): Record<string, string> {
+  return {
+    "Content-Type": file.mimeType,
+    "Accept-Ranges": "bytes",
+    // Uploaded filenames are content-addressed (UUID) — safe to cache hard
+    "Cache-Control": "public, max-age=31536000, immutable",
+    "X-Content-Type-Options": "nosniff",
+  };
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> }
+): Promise<Response> {
+  const { path } = await params;
+  const file = await resolveUpload(path);
+  if (!file) return new Response("Not found", { status: 404 });
+
+  const range = request.headers.get("range");
+
+  // Partial content (video seeking, resumed downloads)
+  if (range) {
+    const match = /^bytes=(\d*)-(\d*)$/.exec(range);
+    if (!match || (match[1] === "" && match[2] === "")) {
+      return new Response("Invalid range", { status: 416 });
+    }
+    const start = match[1] === "" ? Math.max(0, file.size - Number(match[2])) : Number(match[1]);
+    const end = match[1] !== "" && match[2] !== "" ? Number(match[2]) : file.size - 1;
+
+    if (start >= file.size || end >= file.size || start > end) {
+      return new Response("Range not satisfiable", {
+        status: 416,
+        headers: { "Content-Range": `bytes */${file.size}` },
+      });
+    }
+
+    const stream = Readable.toWeb(
+      createReadStream(file.filePath, { start, end })
+    ) as ReadableStream;
+
+    return new Response(stream, {
+      status: 206,
+      headers: {
+        ...baseHeaders(file),
+        "Content-Range": `bytes ${start}-${end}/${file.size}`,
+        "Content-Length": String(end - start + 1),
+      },
+    });
+  }
+
+  // Full file
+  const stream = Readable.toWeb(createReadStream(file.filePath)) as ReadableStream;
+  return new Response(stream, {
+    status: 200,
+    headers: { ...baseHeaders(file), "Content-Length": String(file.size) },
+  });
+}
+
+export async function HEAD(
+  request: NextRequest,
+  ctx: { params: Promise<{ path: string[] }> }
+): Promise<Response> {
+  const { path } = await ctx.params;
+  const file = await resolveUpload(path);
+  if (!file) return new Response(null, { status: 404 });
+
+  return new Response(null, {
+    status: 200,
+    headers: { ...baseHeaders(file), "Content-Length": String(file.size) },
+  });
+}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -9,6 +9,12 @@ const TRUSTED_IFRAME_HOSTS = [
 ];
 
 /**
+ * Path prefix for self-hosted videos. Only files under this prefix may be
+ * played via a native <video> tag — external video sources are stripped.
+ */
+const LOCAL_VIDEO_PREFIX = "/uploads/";
+
+/**
  * Regex patterns to detect bare YouTube/Vimeo URLs on their own line.
  * These get auto-converted to responsive iframe embeds before sanitization.
  */
@@ -24,6 +30,14 @@ const VIDEO_URL_PATTERNS: { pattern: RegExp; toEmbed: (match: RegExpExecArray) =
     pattern: /^https?:\/\/(?:www\.)?vimeo\.com\/(\d+)/,
     toEmbed: (m) =>
       `<div class="video-embed"><iframe src="https://player.vimeo.com/video/${m[1]}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe></div>`,
+  },
+  {
+    // Self-hosted MP4: /uploads/blog/file.mp4 (relative path, local only).
+    // Strict charset (\w, dash, dot, slash) prevents attribute injection
+    // since the match is interpolated into the src attribute below.
+    pattern: /^\/uploads\/[\w\-/.]+\.mp4$/,
+    toEmbed: (m) =>
+      `<video class="video-player" controls preload="metadata" src="${m[0]}"></video>`,
   },
 ];
 
@@ -79,11 +93,35 @@ function removeUntrustedIframes(node: Element): void {
 }
 
 /**
+ * DOMPurify post-pass: remove <video> elements whose source is not a local
+ * upload. DOMPurify allows <video> by default, so without this filter a
+ * post author could embed media from arbitrary external hosts.
+ */
+function removeUntrustedVideos(node: HTMLVideoElement): void {
+  // Collect the src attribute plus any <source> children
+  const sources = [
+    node.getAttribute("src"),
+    ...Array.from(node.querySelectorAll("source")).map((s) => s.getAttribute("src")),
+  ].filter((src): src is string => src !== null);
+
+  const allLocal =
+    sources.length > 0 && sources.every((src) => src.startsWith(LOCAL_VIDEO_PREFIX));
+  if (!allLocal) {
+    node.remove();
+    return;
+  }
+
+  // No autoplay on blog posts — keep playback user-initiated
+  node.removeAttribute("autoplay");
+}
+
+/**
  * Render Markdown to sanitized HTML with video embed support.
- * Pipeline: Markdown → marked (with video extension) → DOMPurify (iframe allowlist)
+ * Pipeline: Markdown → marked (with video extension) → DOMPurify
+ * (iframe domain allowlist + local-only <video> sources)
  *
  * @param markdown - Raw Markdown content
- * @returns Sanitized HTML string with trusted video iframes preserved
+ * @returns Sanitized HTML string with trusted video embeds preserved
  */
 export function renderBlogContent(markdown: string): string {
   const rawHtml = marked.parse(markdown) as string;
@@ -100,6 +138,7 @@ export function renderBlogContent(markdown: string): string {
   const wrapper = document.createElement("div");
   wrapper.innerHTML = clean;
   wrapper.querySelectorAll("iframe").forEach(removeUntrustedIframes);
+  wrapper.querySelectorAll("video").forEach(removeUntrustedVideos);
 
   return wrapper.innerHTML;
 }


### PR DESCRIPTION
## Contexte

Le blog n'acceptait que les images à l'upload et seuls les embeds YouTube/Vimeo passaient la sanitization. Impossible de publier un MP4 auto-hébergé.

En route, découverte d'un **bug latent plus large** : Next.js ne sert que les fichiers `public/` présents au build — tout fichier écrit dans le volume Docker au runtime (uploads admin inclus) répond 404 en production.

## Changements

### Rendu vidéo (commit 1)
- **`src/lib/sanitize.ts`** : URL nue `/uploads/...mp4` sur sa propre ligne → player `<video controls preload="metadata">`. Filtre `removeUntrustedVideos` : sources restreintes aux chemins locaux `/uploads/` (hôtes externes strippés, `autoplay` retiré).
- **`next.config.ts`** : directive CSP `media-src 'self'`.
- **`src/app/globals.css`** : classe `.video-player`.

### Service des fichiers runtime (commit 2)
- **`src/app/uploads/[...path]/route.ts`** : route catch-all qui streame les fichiers du volume `uploads` — support Range/206 (seek vidéo), allowlist d'extensions (jpg/png/webp/gif/mp4/pdf), garde anti-traversal, cache immutable. Corrige aussi le 404 des images/PDF uploadés depuis l'admin.

## Tests

- `pnpm test` : **296/296** ✅ (8 tests sanitization vidéo + 8 tests route uploads)
- `pnpm build` : OK, route `ƒ /uploads/[...path]` enregistrée ✅

## Usage

Dans un article, une ligne seule : `/uploads/blog/mini-backyard-2026.mp4` (fichier déjà en place dans le volume).