### PR TITLE
feat(gallery): upload, affichage et insertion de vidéos MP4

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -25,7 +25,7 @@ const nextConfig: NextConfig = {
             "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
             "style-src 'self' 'unsafe-inline'",
             "img-src 'self' data: blob: https://ladtc.be https:",
-            "media-src 'self'",
+            "media-src 'self' blob:",
             "font-src 'self'",
             "connect-src 'self' https://*.sentry.io",
             "frame-src https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com",

--- a/prisma/migrations/20260608200104_add_gallery_media_type/migration.sql
+++ b/prisma/migrations/20260608200104_add_gallery_media_type/migration.sql
@@ -1,0 +1,8 @@
+-- Add media type support to the gallery (images + videos).
+-- Existing rows default to IMAGE so behaviour is unchanged for current photos.
+
+-- CreateEnum
+CREATE TYPE "MediaType" AS ENUM ('IMAGE', 'VIDEO');
+
+-- AlterTable
+ALTER TABLE "GalleryPhoto" ADD COLUMN "mediaType" "MediaType" NOT NULL DEFAULT 'IMAGE';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -324,16 +324,22 @@ model Document {
   @@index([createdAt])
 }
 
+enum MediaType {
+  IMAGE
+  VIDEO
+}
+
 model GalleryPhoto {
-  id           String   @id @default(cuid())
+  id           String    @id @default(cuid())
   url          String
   title        String
   description  String?
   category     String?
+  mediaType    MediaType @default(IMAGE)
   uploadedById String
-  uploadedBy   User     @relation(fields: [uploadedById], references: [id])
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  uploadedBy   User      @relation(fields: [uploadedById], references: [id])
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
 
   @@index([category])
   @@index([createdAt])

--- a/src/__tests__/media.test.ts
+++ b/src/__tests__/media.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  mediaKindFromMime,
+  maxSizeFor,
+  validateMediaFile,
+  MAX_IMAGE_SIZE,
+  MAX_VIDEO_SIZE,
+  ACCEPTED_MIME_TYPES,
+} from "@/lib/media";
+
+// ─── Media classification ────────────────────────────────────────────────────
+
+describe("mediaKindFromMime", () => {
+  it("classifies image MIME types as IMAGE", () => {
+    expect(mediaKindFromMime("image/jpeg")).toBe("IMAGE");
+    expect(mediaKindFromMime("image/png")).toBe("IMAGE");
+    expect(mediaKindFromMime("image/webp")).toBe("IMAGE");
+    expect(mediaKindFromMime("image/gif")).toBe("IMAGE");
+  });
+
+  it("classifies mp4 as VIDEO", () => {
+    expect(mediaKindFromMime("video/mp4")).toBe("VIDEO");
+  });
+
+  it("returns null for unsupported types", () => {
+    expect(mediaKindFromMime("video/quicktime")).toBeNull();
+    expect(mediaKindFromMime("application/pdf")).toBeNull();
+    expect(mediaKindFromMime("text/html")).toBeNull();
+    expect(mediaKindFromMime("")).toBeNull();
+  });
+});
+
+describe("maxSizeFor", () => {
+  it("uses the image ceiling for images and the video ceiling for videos", () => {
+    expect(maxSizeFor("IMAGE")).toBe(MAX_IMAGE_SIZE);
+    expect(maxSizeFor("VIDEO")).toBe(MAX_VIDEO_SIZE);
+  });
+
+  it("allows videos much larger than images", () => {
+    expect(MAX_VIDEO_SIZE).toBeGreaterThan(MAX_IMAGE_SIZE);
+  });
+});
+
+// ─── Upload validation ───────────────────────────────────────────────────────
+
+describe("validateMediaFile", () => {
+  it("accepts a small image", () => {
+    const res = validateMediaFile({ type: "image/png", size: 1_000_000 });
+    expect(res).toEqual({ ok: true, kind: "IMAGE" });
+  });
+
+  it("accepts an mp4 under the video ceiling", () => {
+    const res = validateMediaFile({ type: "video/mp4", size: 50 * 1024 * 1024 });
+    expect(res).toEqual({ ok: true, kind: "VIDEO" });
+  });
+
+  it("rejects an unsupported type", () => {
+    const res = validateMediaFile({ type: "video/quicktime", size: 1000 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.status).toBe(400);
+      expect(res.error).toContain("MP4");
+    }
+  });
+
+  it("rejects an image over 5 MB", () => {
+    const res = validateMediaFile({ type: "image/jpeg", size: MAX_IMAGE_SIZE + 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain("5 Mo");
+  });
+
+  it("rejects a video over 100 MB", () => {
+    const res = validateMediaFile({ type: "video/mp4", size: MAX_VIDEO_SIZE + 1 });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain("100 Mo");
+  });
+
+  it("accepts a video that would be rejected as an image (size between limits)", () => {
+    // 20 MB: over the image ceiling, under the video ceiling
+    const size = 20 * 1024 * 1024;
+    expect(validateMediaFile({ type: "image/png", size }).ok).toBe(false);
+    expect(validateMediaFile({ type: "video/mp4", size }).ok).toBe(true);
+  });
+});
+
+describe("ACCEPTED_MIME_TYPES", () => {
+  it("includes the four image types and mp4", () => {
+    expect(ACCEPTED_MIME_TYPES).toContain("image/jpeg");
+    expect(ACCEPTED_MIME_TYPES).toContain("video/mp4");
+    expect(ACCEPTED_MIME_TYPES).toHaveLength(5);
+  });
+});

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -173,7 +173,7 @@ describe("CSP headers in next.config", () => {
     "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https://ladtc.be https:",
-    "media-src 'self'",
+    "media-src 'self' blob:",
     "font-src 'self'",
     "connect-src 'self' https://*.sentry.io",
     "frame-src https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com",
@@ -195,8 +195,8 @@ describe("CSP headers in next.config", () => {
     expect(cspValue).toContain("https://player.vimeo.com");
   });
 
-  it("restricts media sources to self only", () => {
-    expect(cspValue).toContain("media-src 'self'");
+  it("restricts media sources to self (plus blob for upload previews)", () => {
+    expect(cspValue).toContain("media-src 'self' blob:");
   });
 
   it("allows connections to Sentry for error tracking", () => {

--- a/src/app/(public)/gallery/page.tsx
+++ b/src/app/(public)/gallery/page.tsx
@@ -95,16 +95,27 @@ function Lightbox({
           </button>
         )}
 
-        {/* Image */}
+        {/* Media: video player for videos, image otherwise */}
         <div className="relative flex min-h-[50vh] items-center justify-center">
-          <Image
-            src={photo.url}
-            alt={photo.title}
-            width={1200}
-            height={800}
-            className="max-h-[80vh] w-auto object-contain"
-            priority
-          />
+          {photo.mediaType === "VIDEO" ? (
+            <video
+              key={photo.url}
+              src={photo.url}
+              controls
+              autoPlay
+              playsInline
+              className="max-h-[80vh] w-auto"
+            />
+          ) : (
+            <Image
+              src={photo.url}
+              alt={photo.title}
+              width={1200}
+              height={800}
+              className="max-h-[80vh] w-auto object-contain"
+              priority
+            />
+          )}
         </div>
 
         {/* Caption */}

--- a/src/app/api/admin/gallery/route.ts
+++ b/src/app/api/admin/gallery/route.ts
@@ -3,9 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { galleryPhotoSchema } from "@/lib/schemas";
 import { requireCommittee, isAuthError } from "@/lib/auth-guard";
 import { putLocal } from "@/lib/storage";
-
-const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
-const MAX_SIZE = 5 * 1024 * 1024; // 5 MB
+import { validateMediaFile } from "@/lib/media";
 
 /**
  * GET /api/admin/gallery
@@ -41,18 +39,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "Aucun fichier fourni" }, { status: 400 });
   }
 
-  if (!ALLOWED_TYPES.includes(file.type)) {
-    return NextResponse.json(
-      { error: "Type de fichier non autorisé. Formats acceptés : JPG, PNG, WebP, GIF" },
-      { status: 400 }
-    );
-  }
-
-  if (file.size > MAX_SIZE) {
-    return NextResponse.json(
-      { error: "Le fichier dépasse la taille maximale de 5 Mo" },
-      { status: 400 }
-    );
+  // Type + per-kind size validation (images 5 MB, videos 100 MB)
+  const validation = validateMediaFile(file);
+  if (!validation.ok) {
+    return NextResponse.json({ error: validation.error }, { status: validation.status });
   }
 
   const title = formData.get("title") as string | null;
@@ -80,6 +70,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       title: parsed.data.title,
       description: parsed.data.description ?? null,
       category: parsed.data.category ?? null,
+      mediaType: validation.kind,
       uploadedById: authResult.user.id,
     },
     include: {

--- a/src/components/admin/GalleryMediaPicker.tsx
+++ b/src/components/admin/GalleryMediaPicker.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Loader2, Play, ImagePlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useGallery } from "@/hooks/use-gallery";
+import type { GalleryPhoto } from "@/types";
+
+interface GalleryMediaPickerProps {
+  /** Called with the chosen media when the user picks an item. */
+  onSelect: (media: GalleryPhoto) => void;
+  /** Optional custom trigger label. */
+  label?: string;
+}
+
+/**
+ * Dialog that lets an editor pick an existing gallery item (image or video)
+ * to insert elsewhere — e.g. into a blog article body.
+ *
+ * Pulls the first 50 gallery items. Videos show a play overlay; the caller
+ * decides what to do with the selected media (see BlogPostForm insertion).
+ */
+export function GalleryMediaPicker({
+  onSelect,
+  label = "Insérer un média de la galerie",
+}: GalleryMediaPickerProps): React.ReactNode {
+  const [open, setOpen] = useState(false);
+  const { data, isLoading } = useGallery(1, 50);
+
+  function handlePick(media: GalleryPhoto): void {
+    onSelect(media);
+    setOpen(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          <ImagePlus className="mr-2 h-4 w-4" />
+          {label}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Galerie — choisir un média</DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center p-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : data?.photos && data.photos.length > 0 ? (
+          <div className="grid max-h-[60vh] grid-cols-3 gap-2 overflow-y-auto sm:grid-cols-4 md:grid-cols-5">
+            {data.photos.map((media) => (
+              <button
+                key={media.id}
+                type="button"
+                onClick={() => handlePick(media)}
+                title={media.title}
+                className="group relative aspect-[4/3] overflow-hidden rounded-lg border border-border transition-all hover:border-primary hover:ring-2 hover:ring-primary/20"
+              >
+                {media.mediaType === "VIDEO" ? (
+                  <>
+                    <video
+                      src={media.url}
+                      className="h-full w-full object-cover"
+                      muted
+                      playsInline
+                      preload="metadata"
+                    />
+                    <span className="absolute inset-0 flex items-center justify-center bg-black/30 text-white">
+                      <Play className="h-5 w-5 fill-current" />
+                    </span>
+                  </>
+                ) : (
+                  <Image
+                    src={media.url}
+                    alt={media.title}
+                    fill
+                    className="object-cover"
+                  />
+                )}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-md border border-border p-6 text-center text-sm text-muted-foreground">
+            Aucun média dans la galerie.
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/gallery/GalleryTable.tsx
+++ b/src/components/admin/gallery/GalleryTable.tsx
@@ -24,6 +24,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useDeletePhoto, useUpdatePhoto } from "@/hooks/use-gallery";
 import { formatDate } from "@/lib/utils";
+import { Play } from "lucide-react";
 import type { GalleryPhoto } from "@/types";
 
 interface GalleryTableProps {
@@ -125,13 +126,28 @@ export function GalleryTable({
               <TableRow key={photo.id}>
                 <TableCell>
                   <div className="relative h-12 w-12 overflow-hidden rounded border border-border">
-                    <Image
-                      src={photo.url}
-                      alt={photo.title}
-                      fill
-                      className="object-cover"
-                      sizes="48px"
-                    />
+                    {photo.mediaType === "VIDEO" ? (
+                      <>
+                        <video
+                          src={photo.url}
+                          className="h-full w-full object-cover"
+                          muted
+                          playsInline
+                          preload="metadata"
+                        />
+                        <span className="absolute inset-0 flex items-center justify-center bg-black/30 text-white">
+                          <Play className="h-4 w-4 fill-current" />
+                        </span>
+                      </>
+                    ) : (
+                      <Image
+                        src={photo.url}
+                        alt={photo.title}
+                        fill
+                        className="object-cover"
+                        sizes="48px"
+                      />
+                    )}
                   </div>
                 </TableCell>
                 <TableCell className="font-medium max-w-[300px] truncate">

--- a/src/components/admin/gallery/GalleryUploadForm.tsx
+++ b/src/components/admin/gallery/GalleryUploadForm.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useUploadPhoto } from "@/hooks/use-gallery";
 import { Upload, X, ImageIcon } from "lucide-react";
 import Image from "next/image";
+import { ACCEPT_ATTRIBUTE, validateMediaFile } from "@/lib/media";
 
 /**
  * Gallery photo upload form with drag & drop, title, description, and category fields.
@@ -29,16 +30,24 @@ export function GalleryUploadForm(): React.ReactNode {
   const [uploadProgress, setUploadProgress] = useState(0);
 
   const handleFiles = useCallback((newFiles: FileList | File[]) => {
-    const validFiles = Array.from(newFiles).filter((f) =>
-      ["image/jpeg", "image/png", "image/webp", "image/gif"].includes(f.type)
-    );
-    if (validFiles.length === 0) {
-      setError("Formats acceptés : JPG, PNG, WebP, GIF");
+    const incoming = Array.from(newFiles);
+    // Validate each file's type and per-kind size (images 5 Mo, vidéos 100 Mo).
+    // Reject the whole batch on the first invalid file so the user gets a clear
+    // message rather than a silently dropped file.
+    for (const f of incoming) {
+      const check = validateMediaFile(f);
+      if (!check.ok) {
+        setError(`${f.name} : ${check.error}`);
+        return;
+      }
+    }
+    if (incoming.length === 0) {
+      setError("Formats acceptés : JPG, PNG, WebP, GIF, MP4");
       return;
     }
     setError(null);
-    setFiles(validFiles);
-    setPreviews(validFiles.map((f) => URL.createObjectURL(f)));
+    setFiles(incoming);
+    setPreviews(incoming.map((f) => URL.createObjectURL(f)));
   }, []);
 
   function handleDrop(e: React.DragEvent): void {
@@ -102,7 +111,7 @@ export function GalleryUploadForm(): React.ReactNode {
     <form onSubmit={handleSubmit} className="space-y-6">
       {/* Drag & drop zone */}
       <div>
-        <Label>Photos</Label>
+        <Label>Photos et vidéos</Label>
         <div
           onDrop={handleDrop}
           onDragOver={handleDragOver}
@@ -116,15 +125,15 @@ export function GalleryUploadForm(): React.ReactNode {
         >
           <Upload className="mb-2 h-8 w-8 text-muted-foreground" />
           <p className="text-sm text-muted-foreground">
-            Glissez-déposez vos photos ici ou cliquez pour sélectionner
+            Glissez-déposez vos photos ou vidéos ici ou cliquez pour sélectionner
           </p>
           <p className="mt-1 text-xs text-muted-foreground">
-            JPG, PNG, WebP, GIF — 5 Mo max par fichier
+            Images JPG, PNG, WebP, GIF (5 Mo max) — Vidéos MP4 (100 Mo max)
           </p>
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/jpeg,image/png,image/webp,image/gif"
+            accept={ACCEPT_ATTRIBUTE}
             multiple
             className="hidden"
             onChange={(e) => e.target.files && handleFiles(e.target.files)}
@@ -137,12 +146,24 @@ export function GalleryUploadForm(): React.ReactNode {
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
           {previews.map((src, i) => (
             <div key={src} className="group relative aspect-square overflow-hidden rounded-lg border border-border">
-              <Image
-                src={src}
-                alt={`Aperçu ${i + 1}`}
-                fill
-                className="object-cover"
-              />
+              {files[i]?.type.startsWith("video/") ? (
+                // Local blob preview: a <video> shows the first frame; next/image
+                // can't render video, so it's used only for image files.
+                <video
+                  src={src}
+                  className="h-full w-full object-cover"
+                  muted
+                  playsInline
+                  preload="metadata"
+                />
+              ) : (
+                <Image
+                  src={src}
+                  alt={`Aperçu ${i + 1}`}
+                  fill
+                  className="object-cover"
+                />
+              )}
               <button
                 type="button"
                 onClick={(e) => {

--- a/src/components/cards/PhotoCard.tsx
+++ b/src/components/cards/PhotoCard.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { Play } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { GalleryPhoto } from "@/types";
 
@@ -8,9 +9,12 @@ interface PhotoCardProps {
 }
 
 /**
- * Gallery photo card — displays image, title, and category badge. Click opens lightbox.
+ * Gallery media card — displays an image (or a video first frame with a play
+ * overlay), title, and category badge. Click opens the lightbox.
  */
 export function PhotoCard({ photo, onClick }: PhotoCardProps): React.ReactNode {
+  const isVideo = photo.mediaType === "VIDEO";
+
   return (
     <button
       type="button"
@@ -19,13 +23,32 @@ export function PhotoCard({ photo, onClick }: PhotoCardProps): React.ReactNode {
     >
       <div className="overflow-hidden rounded-lg border border-border bg-card transition-all duration-200 group-hover:border-primary/40">
         <div className="relative aspect-square w-full overflow-hidden bg-muted">
-          <Image
-            src={photo.url}
-            alt={photo.title}
-            fill
-            className="object-cover transition-transform duration-300 group-hover:scale-105"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-          />
+          {isVideo ? (
+            <>
+              {/* preload=metadata shows the first frame as a thumbnail without
+                  downloading the whole video */}
+              <video
+                src={photo.url}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                muted
+                playsInline
+                preload="metadata"
+              />
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                <span className="flex h-12 w-12 items-center justify-center rounded-full bg-black/55 text-white">
+                  <Play className="h-6 w-6 translate-x-0.5 fill-current" />
+                </span>
+              </div>
+            </>
+          ) : (
+            <Image
+              src={photo.url}
+              alt={photo.title}
+              fill
+              className="object-cover transition-transform duration-300 group-hover:scale-105"
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            />
+          )}
         </div>
         <div className="p-3">
           <h3 className="line-clamp-1 text-sm font-medium text-foreground">

--- a/src/components/forms/BlogPostForm.tsx
+++ b/src/components/forms/BlogPostForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
@@ -23,6 +23,8 @@ import {
 import { slugify } from "@/lib/utils";
 import { CalendarDays, Info } from "lucide-react";
 import { ImagePicker } from "@/components/admin/ImagePicker";
+import { GalleryMediaPicker } from "@/components/admin/GalleryMediaPicker";
+import type { GalleryPhoto } from "@/types";
 
 interface BlogPostFormProps {
   defaultValues?: Partial<BlogPostFormData>;
@@ -48,6 +50,7 @@ export function BlogPostForm({
     handleSubmit,
     control,
     setValue,
+    getValues,
     formState: { errors, isSubmitting: formSubmitting },
   } = useForm<BlogPostFormData>({
     resolver: zodResolver(blogPostSchema),
@@ -74,6 +77,53 @@ export function BlogPostForm({
       setValue("slug", slugify(title));
     }
   }, [title, isEditing, setValue]);
+
+  // Merge RHF's ref with our own so we can insert text at the caret position.
+  const { ref: contentFieldRef, ...contentField } = register("content");
+  const contentRef = useRef<HTMLTextAreaElement | null>(null);
+
+  /**
+   * Insert a gallery media reference into the content textarea at the caret.
+   * Images become Markdown image syntax; videos become a bare /uploads URL on
+   * its own line, which the blog renderer turns into a <video> player.
+   */
+  function insertGalleryMedia(media: GalleryPhoto): void {
+    const snippet =
+      media.mediaType === "VIDEO"
+        ? media.url // bare URL on its own line → rendered as a video player
+        : `![${media.title}](${media.url})`;
+
+    const textarea = contentRef.current;
+    const current = getValues("content") ?? "";
+
+    // Without a live textarea reference, fall back to appending.
+    if (!textarea) {
+      const next = current ? `${current}\n\n${snippet}\n` : `${snippet}\n`;
+      setValue("content", next, { shouldDirty: true, shouldValidate: true });
+      return;
+    }
+
+    const start = textarea.selectionStart ?? current.length;
+    const end = textarea.selectionEnd ?? current.length;
+    const before = current.slice(0, start);
+    const after = current.slice(end);
+
+    // Ensure the snippet sits on its own paragraph (blank line before/after),
+    // which is required for the video URL to be detected as an embed.
+    const prefix = before.length === 0 || before.endsWith("\n\n") ? "" : before.endsWith("\n") ? "\n" : "\n\n";
+    const suffix = after.startsWith("\n\n") || after.length === 0 ? "" : after.startsWith("\n") ? "\n" : "\n\n";
+    const insertion = `${prefix}${snippet}${suffix}`;
+    const next = before + insertion + after;
+
+    setValue("content", next, { shouldDirty: true, shouldValidate: true });
+
+    // Restore focus and place the caret right after the inserted snippet.
+    requestAnimationFrame(() => {
+      const caret = before.length + insertion.length;
+      textarea.focus();
+      textarea.setSelectionRange(caret, caret);
+    });
+  }
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
@@ -111,13 +161,20 @@ export function BlogPostForm({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="content">Contenu (Markdown)</Label>
+        <div className="flex items-center justify-between gap-2">
+          <Label htmlFor="content">Contenu (Markdown)</Label>
+          <GalleryMediaPicker onSelect={insertGalleryMedia} />
+        </div>
         <textarea
           id="content"
           rows={15}
           placeholder="Rédigez votre article en Markdown..."
           className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 font-mono"
-          {...register("content")}
+          ref={(el) => {
+            contentFieldRef(el);
+            contentRef.current = el;
+          }}
+          {...contentField}
         />
         {errors.content && (
           <p className="text-sm text-destructive">{errors.content.message}</p>

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared media constants and helpers for uploads (gallery, blog).
+ *
+ * Centralised here so the upload API, the client upload form, and any future
+ * consumer agree on accepted types and size limits instead of duplicating
+ * (and drifting) the rules.
+ */
+
+/** Image MIME types accepted across the app. */
+export const IMAGE_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+] as const;
+
+/** Video MIME types accepted across the app. */
+export const VIDEO_MIME_TYPES = ["video/mp4"] as const;
+
+/** Every MIME type accepted by media uploads. */
+export const ACCEPTED_MIME_TYPES = [...IMAGE_MIME_TYPES, ...VIDEO_MIME_TYPES];
+
+/** Comma-separated list for an <input type="file" accept="..."> attribute. */
+export const ACCEPT_ATTRIBUTE = ACCEPTED_MIME_TYPES.join(",");
+
+/** Size ceilings per media kind. */
+export const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5 MB
+export const MAX_VIDEO_SIZE = 100 * 1024 * 1024; // 100 MB
+
+/**
+ * Media kind stored on GalleryPhoto.mediaType. Mirrors the Prisma `MediaType`
+ * enum as a string union so client components don't import the generated client.
+ */
+export type MediaKind = "IMAGE" | "VIDEO";
+
+/**
+ * Classify a MIME type into a media kind.
+ * @returns "IMAGE" | "VIDEO", or null if the type is not accepted.
+ */
+export function mediaKindFromMime(mime: string): MediaKind | null {
+  if ((IMAGE_MIME_TYPES as readonly string[]).includes(mime)) return "IMAGE";
+  if ((VIDEO_MIME_TYPES as readonly string[]).includes(mime)) return "VIDEO";
+  return null;
+}
+
+/** Maximum allowed byte size for a given media kind. */
+export function maxSizeFor(kind: MediaKind): number {
+  return kind === "VIDEO" ? MAX_VIDEO_SIZE : MAX_IMAGE_SIZE;
+}
+
+/** Human-readable size (e.g. "100 Mo"), for error messages and hints. */
+export function formatMaxSize(kind: MediaKind): string {
+  return `${maxSizeFor(kind) / (1024 * 1024)} Mo`;
+}
+
+interface MediaValidationOk {
+  ok: true;
+  kind: MediaKind;
+}
+interface MediaValidationError {
+  ok: false;
+  status: number;
+  error: string;
+}
+
+/**
+ * Validate an uploaded file's type and size against the per-kind rules.
+ * @param file - Type/size of the uploaded file (subset of the File interface)
+ * @returns A discriminated result: the kind on success, or an HTTP status + message.
+ */
+export function validateMediaFile(file: {
+  type: string;
+  size: number;
+}): MediaValidationOk | MediaValidationError {
+  const kind = mediaKindFromMime(file.type);
+  if (!kind) {
+    return {
+      ok: false,
+      status: 400,
+      error: "Type de fichier non autorisé. Formats acceptés : JPG, PNG, WebP, GIF, MP4",
+    };
+  }
+  if (file.size > maxSizeFor(kind)) {
+    return {
+      ok: false,
+      status: 400,
+      error: `Le fichier dépasse la taille maximale de ${formatMaxSize(kind)}`,
+    };
+  }
+  return { ok: true, kind };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -247,6 +247,7 @@ export interface GalleryPhoto {
   title: string;
   description: string | null;
   category: string | null;
+  mediaType: "IMAGE" | "VIDEO";
   uploadedById: string;
   uploadedBy: { id: string; name: string | null };
   createdAt: string;


### PR DESCRIPTION
## Contexte

La galerie ne gérait que des images. Cette PR ajoute le support complet des vidéos MP4 : upload depuis l'admin, affichage dans la galerie publique, et insertion dans le corps d'un article de blog.

Fait suite à #28 (lecture de MP4 auto-hébergés via une ligne `/uploads/...mp4` dans un article).

## Changements

### Données
- **`prisma/schema.prisma`** : enum `MediaType { IMAGE VIDEO }` + champ `GalleryPhoto.mediaType` (`@default(IMAGE)`).
- **Migration** `20260608200104_add_gallery_media_type` : `CREATE TYPE` + `ALTER TABLE` (les lignes existantes passent à IMAGE). Appliquée au déploiement via `prisma migrate deploy` (entrypoint).

### Logique partagée
- **`src/lib/media.ts`** (nouveau) : types acceptés + plafonds par nature (image **5 Mo**, vidéo **100 Mo**) + `validateMediaFile()`. Source unique réutilisée par l'API et le formulaire (évite la divergence des règles).

### API
- **`/api/admin/gallery`** : accepte `video/mp4`, validation taille par nature, déduit et stocke `mediaType`. Les routes GET exposent `mediaType` (déjà via `include`).

### Admin
- **Formulaire d'upload** : accepte MP4, aperçu `<video>`, libellés/limites mis à jour, validation client par fichier.
- **Table galerie** : indicateur vidéo (icône play sur la vignette).

### Public
- **PhotoCard** : vignette = première frame de la vidéo + overlay play.
- **Lightbox** : lecteur `<video controls autoplay>` pour les vidéos, `<Image>` pour les images.

### Insertion article
- **`GalleryMediaPicker`** (nouveau) : dialog listant les médias de la galerie (images + vidéos).
- **`BlogPostForm`** : bouton « Insérer un média de la galerie » au-dessus du champ Contenu — insère au curseur `![titre](url)` pour une image, ou l'URL nue sur sa propre ligne pour une vidéo (rendue en lecteur par l'extension marked de #28).

### Sécurité
- **CSP** : `media-src 'self' blob:` (le `blob:` autorise l'aperçu vidéo local dans le formulaire d'upload).

## Tests
- `pnpm test` : **308/308** ✅ (12 nouveaux tests `media.ts`)
- `pnpm lint` : 0 erreur ✅ — `pnpm build` : OK ✅

## Note d'exploitation
Plafond app = 100 Mo. Cloudflare (plan gratuit) limite aussi les uploads à ~100 Mo : un fichier très proche de 100 Mo peut être refusé par l'edge avant d'atteindre l'app. Pour les fichiers plus lourds, le dépôt par SSH dans le volume reste le canal (cf. #28).

## Vérification manuelle conseillée après merge
DB non disponible en local (Docker éteint) → flux upload non testé end-to-end ici. À valider en preview/prod : upload d'un MP4 depuis /admin/gallery, affichage galerie + lightbox, insertion via le picker dans un article.