### PR TITLE
fix(gallery): allow large video uploads (proxy body limit) + legible errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,14 @@ const nextConfig: NextConfig = {
   // Standalone output for Docker deployment
   output: "standalone",
 
+  // With a proxy.ts present, Next buffers every request body (default 10 MB)
+  // and silently truncates beyond it — which corrupts large multipart uploads
+  // (gallery videos) and makes request.formData() throw. Raise the ceiling
+  // above the 100 MB video limit (+ multipart overhead).
+  experimental: {
+    proxyClientMaxBodySize: "110mb",
+  },
+
   // Environment variables
   env: {
     NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",

--- a/src/app/api/admin/gallery/route.ts
+++ b/src/app/api/admin/gallery/route.ts
@@ -32,51 +32,64 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const authResult = await requireCommittee(request);
   if (isAuthError(authResult)) return authResult;
 
-  const formData = await request.formData();
-  const file = formData.get("file") as File | null;
+  try {
+    // Parsing a large multipart body can throw (e.g. body/size limits) — keep it
+    // inside the try so the client gets a JSON error instead of an empty 500.
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
 
-  if (!file) {
-    return NextResponse.json({ error: "Aucun fichier fourni" }, { status: 400 });
-  }
+    if (!file) {
+      return NextResponse.json({ error: "Aucun fichier fourni" }, { status: 400 });
+    }
 
-  // Type + per-kind size validation (images 5 MB, videos 100 MB)
-  const validation = validateMediaFile(file);
-  if (!validation.ok) {
-    return NextResponse.json({ error: validation.error }, { status: validation.status });
-  }
+    // Type + per-kind size validation (images 5 MB, videos 100 MB)
+    const validation = validateMediaFile(file);
+    if (!validation.ok) {
+      return NextResponse.json({ error: validation.error }, { status: validation.status });
+    }
 
-  const title = formData.get("title") as string | null;
-  const description = formData.get("description") as string | null;
-  const category = formData.get("category") as string | null;
+    const title = formData.get("title") as string | null;
+    const description = formData.get("description") as string | null;
+    const category = formData.get("category") as string | null;
 
-  const parsed = galleryPhotoSchema.safeParse({
-    title: title ?? "",
-    description: description || undefined,
-    category: category || undefined,
-  });
+    const parsed = galleryPhotoSchema.safeParse({
+      title: title ?? "",
+      description: description || undefined,
+      category: category || undefined,
+    });
 
-  if (!parsed.success) {
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Données invalides", details: parsed.error.flatten() },
+        { status: 422 }
+      );
+    }
+
+    const result = await putLocal(file, "gallery");
+
+    const photo = await prisma.galleryPhoto.create({
+      data: {
+        url: result.url,
+        title: parsed.data.title,
+        description: parsed.data.description ?? null,
+        category: parsed.data.category ?? null,
+        mediaType: validation.kind,
+        uploadedById: authResult.user.id,
+      },
+      include: {
+        uploadedBy: { select: { id: true, name: true } },
+      },
+    });
+
+    return NextResponse.json({ photo }, { status: 201 });
+  } catch (err) {
+    // Surface the real cause: logged for Sentry/container logs, and returned in
+    // the response (admin-only endpoint) so failures are diagnosable.
+    const message = err instanceof Error ? err.message : "Erreur inconnue";
+    console.error("[gallery upload] échec:", err);
     return NextResponse.json(
-      { error: "Données invalides", details: parsed.error.flatten() },
-      { status: 422 }
+      { error: `Échec de l'upload : ${message}` },
+      { status: 500 }
     );
   }
-
-  const result = await putLocal(file, "gallery");
-
-  const photo = await prisma.galleryPhoto.create({
-    data: {
-      url: result.url,
-      title: parsed.data.title,
-      description: parsed.data.description ?? null,
-      category: parsed.data.category ?? null,
-      mediaType: validation.kind,
-      uploadedById: authResult.user.id,
-    },
-    include: {
-      uploadedBy: { select: { id: true, name: true } },
-    },
-  });
-
-  return NextResponse.json({ photo }, { status: 201 });
 }

--- a/src/hooks/use-gallery.ts
+++ b/src/hooks/use-gallery.ts
@@ -23,6 +23,25 @@ interface GalleryPhotoResponse {
 }
 
 /**
+ * Extract an error message from a failed Response without assuming a JSON body.
+ * A 500/413 from the server or a proxy can return an empty or HTML body, which
+ * would make `res.json()` throw "Unexpected end of JSON input" and hide the
+ * real status. This reads the body defensively and always returns a message.
+ */
+async function errorMessageFrom(res: Response, fallback: string): Promise<string> {
+  const text = await res.text().catch(() => "");
+  if (text) {
+    try {
+      const data = JSON.parse(text) as { error?: string };
+      if (data.error) return data.error;
+    } catch {
+      // Body was not JSON (empty, HTML error page…) — fall through.
+    }
+  }
+  return `${fallback} (erreur ${res.status})`;
+}
+
+/**
  * Fetch gallery photos from the public API
  * @param page - Page number
  * @param perPage - Photos per page
@@ -66,8 +85,7 @@ async function uploadPhoto(formData: FormData): Promise<GalleryPhotoResponse> {
     body: formData,
   });
   if (!res.ok) {
-    const err = (await res.json()) as { error?: string };
-    throw new Error(err.error ?? "Impossible d'uploader la photo");
+    throw new Error(await errorMessageFrom(res, "Impossible d'uploader le média"));
   }
   return res.json() as Promise<GalleryPhotoResponse>;
 }
@@ -85,8 +103,7 @@ async function updatePhoto(
     body: JSON.stringify(data),
   });
   if (!res.ok) {
-    const err = (await res.json()) as { error?: string };
-    throw new Error(err.error ?? "Impossible de mettre à jour la photo");
+    throw new Error(await errorMessageFrom(res, "Impossible de mettre à jour le média"));
   }
   return res.json() as Promise<GalleryPhotoResponse>;
 }
@@ -97,8 +114,7 @@ async function updatePhoto(
 async function deletePhoto(id: string): Promise<{ success: boolean }> {
   const res = await fetch(`/api/admin/gallery/${id}`, { method: "DELETE" });
   if (!res.ok) {
-    const err = (await res.json()) as { error?: string };
-    throw new Error(err.error ?? "Impossible de supprimer la photo");
+    throw new Error(await errorMessageFrom(res, "Impossible de supprimer le média"));
   }
   return res.json() as Promise<{ success: boolean }>;
 }


### PR DESCRIPTION
## Cause racine du 500 à l'upload vidéo

L'erreur `Failed to execute 'json' on 'Response': Unexpected end of JSON input` côté navigateur était un **500 à corps vide**.

Le projet a un `src/proxy.ts` (remplaçant du middleware en Next 16). Quand un proxy est présent, **Next bufferise chaque corps de requête avec une limite par défaut de 10 Mo et tronque silencieusement au-delà** ([doc proxyClientMaxBodySize](https://nextjs.org/docs/app/api-reference/config/next-config-js/proxyClientMaxBodySize)). La vidéo de 41 Mo voyait donc son corps multipart coupé à 10 Mo → `request.formData()` échouait à parser → exception non gérée → 500 vide → `res.json()` plantait côté client.

C'est cohérent avec le diagnostic : images 5 Mo OK, vidéo 41 Mo KO, code 500.

## Changements

- **`next.config.ts`** : `experimental.proxyClientMaxBodySize: '110mb'` (au-dessus du plafond vidéo de 100 Mo + overhead multipart) — **le vrai correctif**.
- **`/api/admin/gallery` (POST)** : `try/catch` autour du parsing + stockage → renvoie une erreur **JSON** (et remonte à Sentry) au lieu d'un 500 vide.
- **`use-gallery.ts`** : lecture défensive des réponses d'erreur (plus de `res.json()` aveugle) → un corps vide/non-JSON affiche le statut au lieu d'un message cryptique.

## Tests
- `pnpm test` : **308/308** ✅ — `pnpm build` : OK (config acceptée) ✅ — `pnpm lint` : 0 erreur ✅

## Note
`proxyClientMaxBodySize` est marqué *experimental* dans Next 16, mais c'est l'unique levier pour relever la limite de buffer du proxy. Cloudflare (gratuit) plafonne par ailleurs à ~100 Mo : un fichier très proche de 100 Mo peut être refusé par l'edge avant d'atteindre l'app.