### PR TITLE
fix(blog): vidéos hors du sélecteur d'image à la une + chemins /uploads/ acceptés

### DIFF
--- a/src/__tests__/blog.test.ts
+++ b/src/__tests__/blog.test.ts
@@ -64,6 +64,30 @@ describe("blogPostSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a full https URL as featured image", () => {
+    const result = blogPostSchema.safeParse({
+      ...validPost,
+      featuredImageUrl: "https://example.com/photo.jpg",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a local /images/ path as featured image", () => {
+    const result = blogPostSchema.safeParse({
+      ...validPost,
+      featuredImageUrl: "/images/hero.jpg",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an /uploads/ gallery path as featured image", () => {
+    const result = blogPostSchema.safeParse({
+      ...validPost,
+      featuredImageUrl: "/uploads/gallery/abc-123.jpg",
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("validates partial schema for updates", () => {
     const partial = blogPostSchema.partial();
     const result = partial.safeParse({ title: "Nouveau titre" });

--- a/src/components/admin/ImagePicker.tsx
+++ b/src/components/admin/ImagePicker.tsx
@@ -29,6 +29,11 @@ export function ImagePicker({
   const [externalUrl, setExternalUrl] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { data: galleryData, isLoading: galleryLoading } = useGallery(1, 50);
+  // A featured image must be an image — videos are inserted into the article
+  // body via GalleryMediaPicker, not chosen here.
+  const galleryImages = (galleryData?.photos ?? []).filter(
+    (photo) => photo.mediaType === "IMAGE"
+  );
 
   async function handleFile(file: File): Promise<void> {
     const validTypes = ["image/jpeg", "image/png", "image/webp", "image/gif"];
@@ -164,9 +169,9 @@ export function ImagePicker({
           <div className="flex items-center justify-center p-8">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
-        ) : galleryData?.photos && galleryData.photos.length > 0 ? (
+        ) : galleryImages.length > 0 ? (
           <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
-            {galleryData.photos.map((photo) => (
+            {galleryImages.map((photo) => (
               <button
                 key={photo.id}
                 type="button"
@@ -184,7 +189,7 @@ export function ImagePicker({
           </div>
         ) : (
           <div className="rounded-md border border-border p-6 text-center text-sm text-muted-foreground">
-            Aucune photo dans la galerie.
+            Aucune image dans la galerie.
           </div>
         )}
       </TabsContent>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -273,7 +273,9 @@ export const blogPostSchema = z.object({
   excerpt: z.string().optional(),
   featuredImageUrl: z.union([
     z.string().url("URL d'image invalide"),
+    // Local images: bundled assets (/images/) or uploads (/uploads/, gallery + blog)
     z.string().startsWith("/images/", "Chemin d'image invalide"),
+    z.string().startsWith("/uploads/", "Chemin d'image invalide"),
     z.literal(""),
     z.undefined(),
   ]),


### PR DESCRIPTION
## Symptôme
Sélectionner la vidéo de la galerie pour un article → **« URL d'image invalide »**.

## Causes
1. Le sélecteur d'**image à la une** (ImagePicker, onglet Galerie) listait aussi les **vidéos** depuis #29 — or une image à la une ne peut pas être une vidéo.
2. `featuredImageUrl` (schéma Zod) n'acceptait qu'une URL complète ou un chemin `/images/` — donc même une **image** de la galerie (servie sous `/uploads/gallery/`) était refusée. Bug préexistant, révélé ici.

## Changements
- **`ImagePicker.tsx`** : l'onglet Galerie n'affiche que les images (`mediaType === "IMAGE"`). Les vidéos s'insèrent dans le **corps** de l'article via `GalleryMediaPicker` (bouton « Insérer un média de la galerie » au-dessus du champ Contenu).
- **`schemas.ts`** : `featuredImageUrl` accepte désormais les chemins `/uploads/` (galerie + blog), en plus de `/images/` et des URL complètes.
- **Tests** : image à la une acceptée en https / `/images/` / `/uploads/` — **311/311** ✅, build OK, lint 0 erreur.

## Rappel d'usage
- **Vidéo dans l'article** → bouton « Insérer un média de la galerie » (corps de l'article).
- **Image à la une** → champ dédié (images uniquement).